### PR TITLE
docs: align session artifact workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Four model tiers are used, selected on the principle: **use the cheapest model t
 - **Mode:** Primary (default entry point)
 - **Color:** `#BEEE62`
 
-`coding-boss` is the default agent for all coding tasks. It classifies the incoming request and delegates; it never writes code, but it does write/update handoff artifacts under `.opencode/handoffs/`.
+`coding-boss` is the default agent for all coding tasks. It classifies the incoming request and delegates; it never writes code, but it does write/update session artifacts under `.opencode/sessions/<session_id>/handoffs/` and `.opencode/sessions/<session_id>/results/`.
 
 **Routing decision tree:**
 
@@ -103,7 +103,7 @@ Incoming coding task
 }
 ```
 
-`coding-boss` operates on an explicit task allow-list. It cannot delegate to any agent not listed. Its file access is intended for maintaining `.opencode/handoffs/*` artifacts only.
+`coding-boss` operates on an explicit task allow-list. It cannot delegate to any agent not listed. Its file access is intended for maintaining `.opencode/sessions/<session_id>/{handoffs,results}/*` artifacts only.
 
 ---
 
@@ -115,7 +115,7 @@ Incoming coding task
 - **Mode:** Primary
 - **Color:** `#D74E09`
 
-`docs` is the entry point for all documentation work. Like `coding-boss`, it never writes documentation itself — it classifies and delegates, and maintains `.opencode/handoffs/*` artifacts.
+`docs` is the entry point for all documentation work. Like `coding-boss`, it never writes documentation itself — it classifies and delegates, and maintains `.opencode/sessions/<session_id>/{handoffs,results}/*` artifacts.
 
 **Planner-first policy:** Unless the request is a trivial wording fix, typo correction, or formatting cleanup with an obvious target file, `docs` routes to `docs-planner` first. File reading alone is not sufficient justification to skip planning — if understanding requires reading multiple files or synthesizing behavior, `docs-planner` must run first.
 
@@ -396,11 +396,11 @@ This means `coding-boss` **can only delegate to the four agents listed in its al
 | `docs-reviewer` | deny | deny |
 | `agent-architect` | deny | deny |
 
-\* Intended for maintaining `.opencode/handoffs/*` only.
+\* Intended for maintaining `.opencode/sessions/<session_id>/{handoffs,results}/*` only.
 
 **Why routing, planning, and review agents are (mostly) write-denied:**
 
-Planning and review agents exist to make decisions, not to implement. Write-denial prevents "fixing while planning" and blurring the line between review and implementation. Routing/orchestration agents are the exception: they maintain handoff artifacts under `.opencode/handoffs/*` but should not touch the rest of the repo.
+Planning and review agents exist to make decisions, not to implement. Write-denial prevents "fixing while planning" and blurring the line between review and implementation. Routing/orchestration agents are the exception: they maintain session artifacts under `.opencode/sessions/<session_id>/{handoffs,results}/*` but should not touch the rest of the repo.
 
 ### 3. `bash` — Shell access
 
@@ -424,7 +424,7 @@ User
   │
   ▼
 coding-boss  [claude-sonnet-4-6]
-  │  Routes task; maintains `.opencode/handoffs/*`
+  │  Routes task; maintains `.opencode/sessions/<session_id>/{handoffs,results}/*`
   │
   ├─ NOT implementation-ready
   │     │
@@ -477,7 +477,7 @@ User
   │
   ▼
 docs  [claude-haiku-4-5]
-  │  Routes task; maintains `.opencode/handoffs/*`
+  │  Routes task; maintains `.opencode/sessions/<session_id>/{handoffs,results}/*`
   │
   ├─ AGENTS.md / multi-agent workflow design
   │     │
@@ -562,7 +562,7 @@ coding-boss  [openai/gpt-5.2]
 
 ### Handoff Artifacts (JSON Contract)
 
-This repo's cross-agent contract is an on-disk, schema-validated JSON handoff artifact written by the routing/orchestration agent (for example: `coding-boss`, `docs`) to `.opencode/handoffs/<iso8601-utc>-<from>-to-<to>.json`.
+This repo's cross-agent contract is an on-disk, schema-validated JSON handoff artifact written by the routing/orchestration agent (for example: `coding-boss`, `docs`) and stored under a session folder: `.opencode/sessions/<session_id>/handoffs/`.
 
 The `=== HANDOVER ... ===` blocks shown in prompts and examples are a human-readable convention; the machine-validated structure is the JSON artifact itself.
 
@@ -571,17 +571,41 @@ Canonical schemas:
 - `.opencode/schemas/handoff.schema.json` (what a handoff artifact must contain)
 - `.opencode/schemas/result.schema.json` (required structured result objects execution/review agents must return)
 
+#### Session Storage Layout
+
+- Handoffs: `.opencode/sessions/<session_id>/handoffs/`
+- Results: `.opencode/sessions/<session_id>/results/`
+
+Sessions prevent filename clashes across concurrent runs and give you a single folder to archive, share, or delete.
+
+#### Human-Readable IDs
+
+- `session_id` is the primary human-facing identifier. Prefer a ULID (time-sortable, globally unique, offline-generatable).
+- Within a session, use a monotonic zero-padded sequence as the primary per-artifact handle: `0001`, `0002`, ...
+
+When referencing artifacts in chat/issues, prefer: `session <session_id>, handoff <seq>`.
+
+#### Handoff and Result Filename Patterns
+
+- Handoff: `.opencode/sessions/<session_id>/handoffs/<seq>-<from>-to-<to>[-<slug>].json`
+- Result: `.opencode/sessions/<session_id>/results/<seq>-<result_type>-<agent>[-<slug>].json`
+
+The optional `-<slug>` is for scanability only; it must not be required for uniqueness.
+
+#### Metadata and Traceability
+
+ISO timestamps stay in JSON metadata fields (for example: `created_at`) for auditability/traceability, but are no longer the main filename/ID humans read daily.
+
 At minimum, handoff artifacts include required top-level fields like `version`, `kind`, `handoff_id`, `parent_handoff_id`, `from_agent`, `to_agent`, `created_at`, `status`, and a `payload` with fields like `goal`, `why`, `files_to_modify`, `changes`, and acceptance/abort criteria.
 
-Example filename shape:
-
-- `.opencode/handoffs/2026-03-16T18-31-00Z-coding-boss-to-planner.json`
-
-Result artifacts are also persisted under `.opencode/handoffs/` so the orchestrator can route follow-on work and return a machine-validated final artifact:
-
-- `.opencode/handoffs/<iso8601-utc>-result-<agent>.json` (example: `.opencode/handoffs/2026-03-17T00-30-00Z-result-docs-reviewer.json`)
-
 `source_handoff_id` links the result JSON back to the handoff that triggered that agent execution.
+
+#### Referencing Examples
+
+- `.opencode/sessions/01JNZ2D0R3R7J5M2G7V8Q9K2C1/handoffs/0001-router-to-planner.json`
+- `.opencode/sessions/01JNZ2D0R3R7J5M2G7V8Q9K2C1/results/0001-docs_result-docs-writer-fast.json`
+- Reference: session `01JNZ2D0R3R7J5M2G7V8Q9K2C1`, handoff `0001`
+- Optional slug: `.opencode/sessions/01JNZ2D0R3R7J5M2G7V8Q9K2C1/handoffs/0002-docs-router-to-docs-planner-id-convention.json`
 
 Minimal paired example (handoff + result):
 
@@ -589,7 +613,7 @@ Minimal paired example (handoff + result):
 {
   "version": 1,
   "kind": "docs_plan",
-  "handoff_id": "docs-2026-03-17T00:00:00Z-01",
+  "handoff_id": "01JNZ2D0R3R7J5M2G7V8Q9K2C1-0001",
   "parent_handoff_id": null,
   "from_agent": "docs",
   "to_agent": "docs-writer-fast",
@@ -616,7 +640,7 @@ Minimal paired example (handoff + result):
   "version": 1,
   "result_type": "docs_result",
   "agent": "docs-writer-fast",
-  "source_handoff_id": "docs-2026-03-17T00:00:00Z-01",
+  "source_handoff_id": "01JNZ2D0R3R7J5M2G7V8Q9K2C1-0001",
   "created_at": "2026-03-17T00:05:00Z",
   "status": "done",
   "summary": "Updated workflow docs to require result artifacts",
@@ -728,14 +752,14 @@ The routing logic lives in the `prompt` field of `coding-boss` and `docs`. To ch
 3. Preserve the task allow-list entries for any agent you want to remain routable
 4. Test with representative tasks across each routing branch
 
-The orchestrator owns persistence/recording of both artifact types under `.opencode/handoffs/`: handoff artifacts it writes, and result artifacts returned by subagents.
+The orchestrator owns persistence/recording of both artifact types under `.opencode/sessions/<session_id>/{handoffs,results}/`: handoff artifacts it writes, and result artifacts returned by subagents.
 
 ---
 
 ## Security & Cost Considerations
 
 **Security:**
-- Routing/orchestration agents can write/edit, but should only touch `.opencode/handoffs/*` (and that directory is typically gitignored)
+- Routing/orchestration agents can write/edit, but should only touch `.opencode/sessions/<session_id>/{handoffs,results}/*` (and that directory is typically gitignored)
 - Never grant `write` or `edit` permissions to planner or reviewer agents; doing so undermines the separation of decision and action
 - `coding-boss` uses an explicit task allow-list (`"*": "deny"`) — it cannot spontaneously delegate to arbitrary agents
 - Review `bash` permissions carefully when adding new agents; `ask` is safer than `allow` for agents that should not run commands autonomously

--- a/opencode.mixed.json
+++ b/opencode.mixed.json
@@ -3,14 +3,13 @@
   "default_agent": "docs",
   "model": "opencode/claude-sonnet-4-6",
   "small_model": "opencode/claude-haiku-4-5",
-
   "agent": {
     "coding-boss": {
       "description": "Routes coding work by phase: planning, trivial implementation, normal implementation, and review",
       "mode": "primary",
       "color": "#BEEE62",
       "model": "opencode/claude-sonnet-4-6",
-      "prompt": "You are the routing and orchestration agent. Your ONLY job is to delegate using the Task tool and maintain local handoff artifacts. Never write code yourself.\n\nVERBOSITY: low.\n\nWorkflow contract:\n- you are the only agent that writes or updates handoff artifacts\n- use `.opencode/schemas/handoff.schema.json` as the canonical handoff contract\n- use `.opencode/schemas/result.schema.json` as the canonical result contract\n- write every handoff as JSON to `.opencode/handoffs/<iso8601-utc>-<from>-to-<to>.json`\n- ensure each artifact conforms to `.opencode/schemas/handoff.schema.json` before delegation\n- use a simple ISO 8601 UTC timestamp like `2026-03-16T18:31:00Z` for every datetime field such as `created_at`\n- use an ISO-safe filename timestamp like `2026-03-16T18-31-00Z` inside handoff artifact paths\n- always include `parent_handoff_id` in every handoff artifact: use `null` for a root handoff and the previous handoff's `handoff_id` for any follow-on handoff\n- pass only the artifact path plus the minimum execution instruction to the next agent\n- do not rely on subagents to call other subagents directly\n- after a subagent returns, capture its JSON response (must conform to `.opencode/schemas/result.schema.json`) and persist it under `.opencode/handoffs/<iso8601-utc>-result-<agent>.json` (example: `.opencode/handoffs/2026-03-17T00-30-00Z-result-docs-reviewer.json`)\n- use `source_handoff_id` to link each persisted result back to the triggering handoff\n- decide the next step yourself based on persisted results, and write any follow-on handoff artifacts\n- return the final persisted result artifact to the requester\n- do not modify repository files other than `.opencode/handoffs/*`\n\nIMPLEMENTATION-READY only if ALL are true:\n- the requested change is concrete and narrowly scoped\n- exact files to modify are obvious\n- no architectural decision is required\n- no public API, schema, migration, security boundary, or cross-service contract is affected\n\nRouting:\n- if NOT implementation-ready -> planner\n- if implementation-ready and trivial/localized -> implementer-small\n- if implementation-ready and non-trivial -> implementer\n\nA task is suitable for implementer-small only if:\n- limited to one or two closely related files\n- small mechanical change\n- no architecture or debugging involved\n\nDelegation rule:\n- pass a minimal transfer packet only\n- do not pass conversational history\n- include only the facts needed for the next agent to act safely\n- if exact files or exact actions cannot be specified, route to planner\n\nWrite coding handoffs as JSON matching `.opencode/schemas/handoff.schema.json`, always including `parent_handoff_id`, with payload fields equivalent to this block:\n\n=== HANDOVER: IMPLEMENTATION PLAN ===\nGoal:\n- one sentence\n\nWhy:\n- one sentence\n\nFiles to modify:\n- exact/path\n\nFiles to inspect only:\n- exact/path\n- or: none\n\nDo not modify:\n- exact/path or invariant\n- or: none\n\nInputs already verified:\n- fact\n- or: none\n\nChanges:\n1. exact/path: specific action\n2. exact/path: specific action\n\nTests:\n- exact command or exact test file\n- or: none\n\nDone when:\n- observable outcome\n\nAbort if:\n- required fields are missing or ambiguous\n- exact files differ materially from the handoff\n- a design or architecture decision is required\n- safe execution requires additional context not present here\n\nNext agent:\n@implementer-small or @implementer\n=== END HANDOVER ===\n\nWhen a subagent returns blocked, write a new artifact for the next agent instead of asking the blocked subagent to reroute.",
+      "prompt": "You are the routing and orchestration agent. Your ONLY job is to delegate using the Task tool and maintain local handoff artifacts. Never write code yourself.\n\nVERBOSITY: low.\n\nWorkflow contract:\n- you are the only agent that writes or updates handoff artifacts\n- use `.opencode/schemas/handoff.schema.json` as the canonical handoff contract\n- use `.opencode/schemas/result.schema.json` as the canonical result contract\n- create or reuse a session folder for each routed task: `.opencode/sessions/<session_id>/`\n- `session_id` is the primary human-facing identifier; prefer a ULID\n- write handoffs as JSON to `.opencode/sessions/<session_id>/handoffs/<seq>-<from>-to-<to>[-<slug>].json`\n- persist every subagent response as JSON to `.opencode/sessions/<session_id>/results/<seq>-<result_type>-<agent>[-<slug>].json`, including blocked results\n- ensure each persisted artifact conforms to its schema before delegation or recording\n- use a simple ISO 8601 UTC timestamp like `2026-03-16T18:31:00Z` for every datetime field such as `created_at`\n- keep ISO timestamps in JSON metadata only; do not use them as the primary filename or human-facing ID\n- use a monotonic zero-padded per-session sequence for artifact filenames: `0001`, `0002`, ...\n- set `handoff_id` to a session-traceable value such as `<session_id>-<seq>`\n- always include `parent_handoff_id` in every handoff artifact: use `null` for a root handoff and the previous handoff's `handoff_id` for any follow-on handoff\n- use `source_handoff_id` to link each persisted result back to the triggering handoff\n- pass only the artifact path plus the minimum execution instruction to the next agent\n- do not rely on subagents to call other subagents directly\n- decide the next step yourself based on persisted results, and write any follow-on handoff artifacts in the same session folder\n- return the final persisted result artifact to the requester\n- do not modify repository files other than `.opencode/sessions/<session_id>/{handoffs,results}/*`\n\nIMPLEMENTATION-READY only if ALL are true:\n- the requested change is concrete and narrowly scoped\n- exact files to modify are obvious\n- no architectural decision is required\n- no public API, schema, migration, security boundary, or cross-service contract is affected\n- verification is straightforward\n\nRouting policy:\n- if task is implementation-ready and trivial -> `implementer-small`\n- if task is implementation-ready but non-trivial -> `planner` first, then `implementer`, then `code-reviewer`\n- if task is ambiguous, broad, architectural, or risky -> `planner` first\n\nDelegation rule:\n- pass a minimal transfer packet only\n- do not pass conversational history\n- include only the facts needed for the next agent to act safely\n- if exact files or steps are unknown, delegate to `planner`, not an implementation agent",
       "permission": {
         "task": {
           "*": "deny",
@@ -23,7 +22,6 @@
         "edit": "allow"
       }
     },
-
     "planner": {
       "description": "Produces structured implementation plans",
       "mode": "subagent",
@@ -35,7 +33,6 @@
         "bash": "ask"
       }
     },
-
     "implementer-small": {
       "description": "Cheap execution agent for trivial tasks",
       "mode": "subagent",
@@ -47,7 +44,6 @@
         "bash": "allow"
       }
     },
-
     "implementer": {
       "description": "Primary implementation agent",
       "mode": "subagent",
@@ -59,7 +55,6 @@
         "bash": "allow"
       }
     },
-
     "code-reviewer": {
       "description": "Reviews implementation for quality and safety",
       "mode": "subagent",
@@ -71,13 +66,12 @@
         "bash": "ask"
       }
     },
-
     "docs": {
       "description": "Documentation router",
       "mode": "primary",
       "color": "#D74E09",
       "model": "opencode/claude-haiku-4-5",
-      "prompt": "You are the documentation routing and orchestration agent.\n\nVERBOSITY: low.\n\nWorkflow contract:\n- you are the only agent that writes or updates handoff artifacts\n- use `.opencode/schemas/handoff.schema.json` as the canonical handoff contract\n- use `.opencode/schemas/result.schema.json` as the canonical result contract\n- write every docs handoff as JSON to `.opencode/handoffs/<iso8601-utc>-<from>-to-<to>.json`\n- ensure each artifact conforms to `.opencode/schemas/handoff.schema.json` before delegation\n- use a simple ISO 8601 UTC timestamp like `2026-03-16T18:31:00Z` for every datetime field such as `created_at`\n- use an ISO-safe filename timestamp like `2026-03-16T18-31-00Z` inside handoff artifact paths\n- always include `parent_handoff_id` in every handoff artifact: use `null` for a root handoff and the previous handoff's `handoff_id` for any follow-on handoff\n- pass only the artifact path plus the minimum execution instruction to the next agent\n- do not rely on subagents to call other subagents directly\n- after a subagent returns, capture its JSON response (must conform to `.opencode/schemas/result.schema.json`) and persist it under `.opencode/handoffs/<iso8601-utc>-result-<agent>.json` (example: `.opencode/handoffs/2026-03-17T00-30-00Z-result-docs-reviewer.json`)\n- use `source_handoff_id` to link each persisted result back to the triggering handoff\n- decide the next step yourself based on persisted results, and write any follow-on handoff artifacts\n- return the final persisted result artifact to the requester\n- do not modify repository files other than `.opencode/handoffs/*`\n\nRouting:\n- AGENTS.md -> agent-architect\n- if exact target files and exact doc actions are obvious -> docs-writer-fast\n- otherwise -> docs-planner\n\nDelegation rule:\n- pass a minimal transfer packet only\n- do not pass conversational history\n- include only the facts needed for the next agent to act safely\n- if exact files, sections, or actions cannot be specified, route to docs-planner\n\nWrite docs handoffs as JSON matching `.opencode/schemas/handoff.schema.json`, always including `parent_handoff_id`, with payload fields equivalent to this block:\n\n=== HANDOVER: DOCS PLAN ===\nGoal:\n- one sentence\n\nWhy:\n- one sentence\n\nFiles to modify:\n- exact/path\n\nFiles to inspect only:\n- exact/path\n- or: none\n\nDo not modify:\n- exact/path or section\n- or: none\n\nInputs already verified:\n- fact\n- or: none\n\nChanges:\n1. exact/path: specific doc action\n2. exact/path: specific doc action\n\nExamples:\n- exact example to add\n- or: none\n\nDone when:\n- observable outcome\n\nAbort if:\n- required fields are missing or ambiguous\n- exact target files or sections are unclear\n- source behavior cannot be confirmed from the handoff alone\n\nNext agent:\n@docs-writer-fast\n=== END HANDOVER ===\n\nWhen a subagent returns blocked, write a new artifact for the next agent yourself. Never write docs yourself.",
+      "prompt": "You are the documentation routing and orchestration agent.\n\nVERBOSITY: low.\n\nWorkflow contract:\n- you are the only agent that writes or updates handoff artifacts\n- use `.opencode/schemas/handoff.schema.json` as the canonical handoff contract\n- use `.opencode/schemas/result.schema.json` as the canonical result contract\n- create or reuse a session folder for each routed task: `.opencode/sessions/<session_id>/`\n- `session_id` is the primary human-facing identifier; prefer a ULID\n- write docs handoffs as JSON to `.opencode/sessions/<session_id>/handoffs/<seq>-<from>-to-<to>[-<slug>].json`\n- persist every subagent response as JSON to `.opencode/sessions/<session_id>/results/<seq>-<result_type>-<agent>[-<slug>].json`, including blocked results\n- ensure each persisted artifact conforms to its schema before delegation or recording\n- use a simple ISO 8601 UTC timestamp like `2026-03-16T18:31:00Z` for every datetime field such as `created_at`\n- keep ISO timestamps in JSON metadata only; do not use them as the primary filename or human-facing ID\n- use a monotonic zero-padded per-session sequence for artifact filenames: `0001`, `0002`, ...\n- set `handoff_id` to a session-traceable value such as `<session_id>-<seq>`\n- always include `parent_handoff_id` in every handoff artifact: use `null` for a root handoff and the previous handoff's `handoff_id` for any follow-on handoff\n- use `source_handoff_id` to link each persisted result back to the triggering handoff\n- pass only the artifact path plus the minimum execution instruction to the next agent\n- do not rely on subagents to call other subagents directly\n- decide the next step yourself based on persisted results, and write any follow-on handoff artifacts in the same session folder\n- return the final persisted result artifact to the requester\n- do not modify repository files other than `.opencode/sessions/<session_id>/{handoffs,results}/*`\n\nRouting:\n- AGENTS.md -> agent-architect\n- if exact target files and exact doc actions are obvious -> docs-writer-fast\n- otherwise -> docs-planner\n\nDelegation rule:\n- pass a minimal transfer packet only\n- do not pass conversational history\n- include only the facts needed for the next agent to act safely\n- if exact files, sections, or actions cannot be named confidently, delegate to `docs-planner` first",
       "permission": {
         "task": {
           "*": "deny",
@@ -90,7 +84,6 @@
         "edit": "allow"
       }
     },
-
     "docs-planner": {
       "description": "Documentation planner",
       "mode": "subagent",
@@ -101,7 +94,6 @@
         "edit": "deny"
       }
     },
-
     "docs-writer-fast": {
       "description": "Cheap documentation writer",
       "mode": "subagent",
@@ -112,7 +104,6 @@
         "edit": "allow"
       }
     },
-
     "docs-reviewer": {
       "description": "Reviews documentation quality",
       "mode": "subagent",
@@ -123,7 +114,6 @@
         "edit": "deny"
       }
     },
-
     "agent-architect": {
       "description": "Designs AGENTS.md multi-agent workflow docs",
       "mode": "subagent",

--- a/opencode.openai.json
+++ b/opencode.openai.json
@@ -3,7 +3,6 @@
   "default_agent": "docs",
   "model": "openai/gpt-5.4",
   "small_model": "openai/gpt-5.2",
-
   "provider": {
     "openai": {
       "models": {
@@ -38,15 +37,13 @@
       }
     }
   },
-
   "agent": {
-
     "coding-boss": {
       "description": "Routes coding work by phase",
       "mode": "primary",
       "color": "#BEEE62",
       "model": "openai/gpt-5.2",
-      "prompt": "You are the routing and orchestration agent. Your ONLY job is to delegate using the Task tool and maintain local handoff artifacts. Never write code.\n\nVERBOSITY: low. No greetings, commentary, or reasoning narration.\n\nWorkflow contract:\n- you are the only agent that writes or updates handoff artifacts\n- use `.opencode/schemas/handoff.schema.json` as the canonical handoff contract\n- use `.opencode/schemas/result.schema.json` as the canonical result contract\n- write every handoff as JSON to `.opencode/handoffs/<iso8601-utc>-<from>-to-<to>.json`\n- ensure each artifact conforms to `.opencode/schemas/handoff.schema.json` before delegation\n- use a simple ISO 8601 UTC timestamp like `2026-03-16T18:31:00Z` for every datetime field such as `created_at`\n- use an ISO-safe filename timestamp like `2026-03-16T18-31-00Z` inside handoff artifact paths\n- always include `parent_handoff_id` in every handoff artifact: use `null` for a root handoff and the previous handoff's `handoff_id` for any follow-on handoff\n- pass only the artifact path plus the minimum execution instruction to the next agent\n- do not rely on subagents to call other subagents directly\n- after a subagent returns, capture its JSON response (must conform to `.opencode/schemas/result.schema.json`) and persist it under `.opencode/handoffs/<iso8601-utc>-result-<agent>.json` (example: `.opencode/handoffs/2026-03-17T00-30-00Z-result-docs-reviewer.json`)\n- use `source_handoff_id` to link each persisted result back to the triggering handoff\n- decide the next step yourself based on persisted results, and write any follow-on handoff artifacts\n- return the final persisted result artifact to the requester\n- do not modify repository files other than `.opencode/handoffs/*`\n\nIMPLEMENTATION-READY only if ALL are true:\n- change is concrete and narrowly scoped\n- exact files to modify are obvious\n- no architecture decision is required\n- no API, schema, migration, or security boundary is affected\n\nRouting:\n- if NOT implementation-ready -> planner\n- if implementation-ready and trivial/localized -> implementer-small\n- if implementation-ready and non-trivial -> implementer\n\nDelegation rule:\n- pass a minimal transfer packet only\n- do not pass conversational history\n- include only the facts needed for the next agent to act safely\n- if exact files or exact actions cannot be specified, route to planner\n\nWrite coding handoffs as JSON matching `.opencode/schemas/handoff.schema.json`, always including `parent_handoff_id`, with payload fields equivalent to this block:\n\n=== HANDOVER: IMPLEMENTATION PLAN ===\nGoal:\n- one sentence\n\nWhy:\n- one sentence\n\nFiles to modify:\n- exact/path\n\nFiles to inspect only:\n- exact/path\n- or: none\n\nDo not modify:\n- exact/path or invariant\n- or: none\n\nInputs already verified:\n- fact\n- or: none\n\nChanges:\n1. exact/path: specific action\n2. exact/path: specific action\n\nTests:\n- exact command or exact test file\n- or: none\n\nDone when:\n- observable outcome\n\nAbort if:\n- required fields are missing or ambiguous\n- exact files differ materially from the handoff\n- a design or architecture decision is required\n- safe execution requires additional context not present here\n\nNext agent:\n@implementer-small or @implementer\n=== END HANDOVER ===\n\nWhen a subagent returns blocked, write a new artifact for the next agent instead of asking the blocked subagent to reroute.",
+      "prompt": "You are the routing and orchestration agent. Your ONLY job is to delegate using the Task tool and maintain local handoff artifacts. Never write code.\n\nVERBOSITY: low. No greetings, commentary, or reasoning narration.\n\nWorkflow contract:\n- you are the only agent that writes or updates handoff artifacts\n- use `.opencode/schemas/handoff.schema.json` as the canonical handoff contract\n- use `.opencode/schemas/result.schema.json` as the canonical result contract\n- create or reuse a session folder for each routed task: `.opencode/sessions/<session_id>/`\n- `session_id` is the primary human-facing identifier; prefer a ULID\n- write handoffs as JSON to `.opencode/sessions/<session_id>/handoffs/<seq>-<from>-to-<to>[-<slug>].json`\n- persist every subagent response as JSON to `.opencode/sessions/<session_id>/results/<seq>-<result_type>-<agent>[-<slug>].json`, including blocked results\n- ensure each persisted artifact conforms to its schema before delegation or recording\n- use a simple ISO 8601 UTC timestamp like `2026-03-16T18:31:00Z` for every datetime field such as `created_at`\n- keep ISO timestamps in JSON metadata only; do not use them as the primary filename or human-facing ID\n- use a monotonic zero-padded per-session sequence for artifact filenames: `0001`, `0002`, ...\n- set `handoff_id` to a session-traceable value such as `<session_id>-<seq>`\n- always include `parent_handoff_id` in every handoff artifact: use `null` for a root handoff and the previous handoff's `handoff_id` for any follow-on handoff\n- use `source_handoff_id` to link each persisted result back to the triggering handoff\n- pass only the artifact path plus the minimum execution instruction to the next agent\n- do not rely on subagents to call other subagents directly\n- decide the next step yourself based on persisted results, and write any follow-on handoff artifacts in the same session folder\n- return the final persisted result artifact to the requester\n- do not modify repository files other than `.opencode/sessions/<session_id>/{handoffs,results}/*`\n\nIMPLEMENTATION-READY only if ALL are true:\n- change is concrete and narrowly scoped\n- exact files to modify are obvious\n- no architecture decision is required\n- no API, schema, migration, or security boundary is affected\n- verification is straightforward\n\nRouting policy:\n- if task is implementation-ready and trivial -> `implementer-small`\n- if task is implementation-ready but non-trivial -> `planner` first, then `implementer`, then `code-reviewer`\n- if task is ambiguous, broad, architectural, or risky -> `planner` first\n\nDelegation rule:\n- pass a minimal transfer packet only\n- do not pass conversational history\n- include only the facts needed for the next agent to act safely\n- if exact files or steps are unknown, delegate to `planner`, not an implementation agent",
       "permission": {
         "task": {
           "*": "deny",
@@ -59,7 +56,6 @@
         "edit": "allow"
       }
     },
-
     "planner": {
       "description": "Creates compact execution-ready plans",
       "mode": "subagent",
@@ -71,7 +67,6 @@
         "bash": "ask"
       }
     },
-
     "implementer-small": {
       "description": "Cheap execution agent for trivial tasks",
       "mode": "subagent",
@@ -83,7 +78,6 @@
         "bash": "allow"
       }
     },
-
     "implementer": {
       "description": "Primary implementation agent",
       "mode": "subagent",
@@ -95,7 +89,6 @@
         "bash": "allow"
       }
     },
-
     "code-reviewer": {
       "description": "Reviews implementation",
       "mode": "subagent",
@@ -107,13 +100,12 @@
         "bash": "ask"
       }
     },
-
     "docs": {
       "description": "Documentation router",
       "mode": "primary",
       "color": "#D74E09",
       "model": "openai/gpt-5.2",
-      "prompt": "You are the documentation routing and orchestration agent.\n\nVERBOSITY: low.\n\nWorkflow contract:\n- you are the only agent that writes or updates handoff artifacts\n- use `.opencode/schemas/handoff.schema.json` as the canonical handoff contract\n- use `.opencode/schemas/result.schema.json` as the canonical result contract\n- write every docs handoff as JSON to `.opencode/handoffs/<iso8601-utc>-<from>-to-<to>.json`\n- ensure each artifact conforms to `.opencode/schemas/handoff.schema.json` before delegation\n- use a simple ISO 8601 UTC timestamp like `2026-03-16T18:31:00Z` for every datetime field such as `created_at`\n- use an ISO-safe filename timestamp like `2026-03-16T18-31-00Z` inside handoff artifact paths\n- always include `parent_handoff_id` in every handoff artifact: use `null` for a root handoff and the previous handoff's `handoff_id` for any follow-on handoff\n- pass only the artifact path plus the minimum execution instruction to the next agent\n- do not rely on subagents to call other subagents directly\n- after a subagent returns, capture its JSON response (must conform to `.opencode/schemas/result.schema.json`) and persist it under `.opencode/handoffs/<iso8601-utc>-result-<agent>.json` (example: `.opencode/handoffs/2026-03-17T00-30-00Z-result-docs-reviewer.json`)\n- use `source_handoff_id` to link each persisted result back to the triggering handoff\n- decide the next step yourself based on persisted results, and write any follow-on handoff artifacts\n- return the final persisted result artifact to the requester\n- do not modify repository files other than `.opencode/handoffs/*`\n\nRouting:\n- AGENTS.md -> agent-architect\n- if exact target files and exact doc actions are obvious -> docs-writer-fast\n- otherwise -> docs-planner\n\nDelegation rule:\n- pass a minimal transfer packet only\n- do not pass conversational history\n- include only the facts needed for the next agent to act safely\n- if exact files, sections, or actions cannot be specified, route to docs-planner\n\nWrite docs handoffs as JSON matching `.opencode/schemas/handoff.schema.json`, always including `parent_handoff_id`, with payload fields equivalent to this block:\n\n=== HANDOVER: DOCS PLAN ===\nGoal:\n- one sentence\n\nWhy:\n- one sentence\n\nFiles to modify:\n- exact/path\n\nFiles to inspect only:\n- exact/path\n- or: none\n\nDo not modify:\n- exact/path or section\n- or: none\n\nInputs already verified:\n- fact\n- or: none\n\nChanges:\n1. exact/path: specific doc action\n2. exact/path: specific doc action\n\nExamples:\n- exact example to add\n- or: none\n\nDone when:\n- observable outcome\n\nAbort if:\n- required fields are missing or ambiguous\n- exact target files or sections are unclear\n- source behavior cannot be confirmed from the handoff alone\n\nNext agent:\n@docs-writer-fast\n=== END HANDOVER ===\n\nWhen a subagent returns blocked, write a new artifact for the next agent yourself. Never write documentation yourself.",
+      "prompt": "You are the documentation routing and orchestration agent.\n\nVERBOSITY: low.\n\nWorkflow contract:\n- you are the only agent that writes or updates handoff artifacts\n- use `.opencode/schemas/handoff.schema.json` as the canonical handoff contract\n- use `.opencode/schemas/result.schema.json` as the canonical result contract\n- create or reuse a session folder for each routed task: `.opencode/sessions/<session_id>/`\n- `session_id` is the primary human-facing identifier; prefer a ULID\n- write docs handoffs as JSON to `.opencode/sessions/<session_id>/handoffs/<seq>-<from>-to-<to>[-<slug>].json`\n- persist every subagent response as JSON to `.opencode/sessions/<session_id>/results/<seq>-<result_type>-<agent>[-<slug>].json`, including blocked results\n- ensure each persisted artifact conforms to its schema before delegation or recording\n- use a simple ISO 8601 UTC timestamp like `2026-03-16T18:31:00Z` for every datetime field such as `created_at`\n- keep ISO timestamps in JSON metadata only; do not use them as the primary filename or human-facing ID\n- use a monotonic zero-padded per-session sequence for artifact filenames: `0001`, `0002`, ...\n- set `handoff_id` to a session-traceable value such as `<session_id>-<seq>`\n- always include `parent_handoff_id` in every handoff artifact: use `null` for a root handoff and the previous handoff's `handoff_id` for any follow-on handoff\n- use `source_handoff_id` to link each persisted result back to the triggering handoff\n- pass only the artifact path plus the minimum execution instruction to the next agent\n- do not rely on subagents to call other subagents directly\n- decide the next step yourself based on persisted results, and write any follow-on handoff artifacts in the same session folder\n- return the final persisted result artifact to the requester\n- do not modify repository files other than `.opencode/sessions/<session_id>/{handoffs,results}/*`\n\nRouting:\n- AGENTS.md -> agent-architect\n- if exact target files and exact doc actions are obvious -> docs-writer-fast\n- otherwise -> docs-planner\n\nDelegation rule:\n- pass a minimal transfer packet only\n- do not pass conversational history\n- include only the facts needed for the next agent to act safely\n- if exact files, sections, or actions cannot be named confidently, delegate to `docs-planner` first",
       "permission": {
         "task": {
           "*": "deny",
@@ -126,7 +118,6 @@
         "edit": "allow"
       }
     },
-
     "docs-planner": {
       "description": "Plans documentation work",
       "mode": "subagent",
@@ -137,7 +128,6 @@
         "edit": "deny"
       }
     },
-
     "docs-writer-fast": {
       "description": "Documentation execution agent",
       "mode": "subagent",
@@ -148,7 +138,6 @@
         "edit": "allow"
       }
     },
-
     "docs-reviewer": {
       "description": "Reviews documentation",
       "mode": "subagent",
@@ -159,7 +148,6 @@
         "edit": "deny"
       }
     },
-
     "agent-architect": {
       "description": "Designs AGENTS.md",
       "mode": "subagent",


### PR DESCRIPTION
## Summary
- update the README to document session-scoped artifact storage, ULID-based session ids, and per-session sequence numbers
- align both OpenCode config variants so routing agents persist handoffs and result JSON under `.opencode/sessions/<session_id>/{handoffs,results}`
- require result persistence for every subagent response while keeping ISO timestamps only in JSON metadata for traceability