### PR TITLE
docs: correct US-012 traceability

### DIFF
--- a/docs/opencode-helper-cli.md
+++ b/docs/opencode-helper-cli.md
@@ -491,10 +491,10 @@ Priority:
 - P0
 
 Status:
-- Done
+- Planned
 
 PR:
-- https://github.com/sven1103-agent/opencode-agents/pull/15
+- TBD
 
 Type:
 - User-facing
@@ -841,10 +841,10 @@ Priority:
 - P0
 
 Status:
-- Planned
+- Done
 
 PR:
-- TBD
+- https://github.com/sven1103-agent/opencode-agents/pull/15
 
 Type:
 - User-facing


### PR DESCRIPTION
## Summary
- correct `docs/opencode-helper-cli.md` so PR #15 is linked from `US-012` instead of `US-001`
- restore `US-001` to `Status: Planned` with `PR: TBD`
- document the root cause: the earlier traceability edit matched a repeated `Status/PR` block without anchoring on the `US-012` heading