### PR TITLE
docs: fix US-017 traceability

### DIFF
--- a/docs/opencode-helper-cli.md
+++ b/docs/opencode-helper-cli.md
@@ -772,10 +772,10 @@ Priority:
 - P1
 
 Status:
-- Planned
+- Done
 
 PR:
-- TBD
+- [#28](https://github.com/sven1103-agent/opencode-agents/pull/28)
 
 Type:
 - User-facing


### PR DESCRIPTION
## What
- Fix user story traceability for US-017.

## Why
- US-017 was completed in PR #28 but the backlog entry still showed Planned/TBD.