### PR TITLE
docs: disambiguate user story traceability

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,12 +3,13 @@
 This PR implements a user story from `docs/opencode-helper-cli.md`.
 
 Required:
-- Title starts with `US-###: ...`
-- Body includes an `Implements: US-###` line
+- Title starts with `US-###: ...` (primary story only)
+- Body includes an `Implements: US-###` line (primary story)
 
 ## Story
 
 Implements: US-###
+Also advances: (optional) US-###, US-###
 PRD: docs/opencode-helper-cli.md#us-###
 
 ## Acceptance Criteria
@@ -26,5 +27,7 @@ PRD: docs/opencode-helper-cli.md#us-###
 
 ## Reviewer Checklist
 
-- [ ] PR title starts with `US-###:` and body includes `Implements: US-###`
-- [ ] `docs/opencode-helper-cli.md` story is updated with `Status: Done` and `PR: <link/#>`
+- [ ] PR title uses primary `US-###:` and body includes `Implements: US-###`
+- [ ] If `Also advances:` is present, those IDs are not marked `Done` unless fully completed
+- [ ] `docs/opencode-helper-cli.md` primary story entry is updated with `PR: <link/#>`
+- [ ] `docs/opencode-helper-cli.md` primary story `Status` is `Done` only when all acceptance criteria are satisfied

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Before doing any substantive work for a new user story or implementation task in
 - Keep changes aligned with the repo's planning-first, schema-validated workflow
 - Preserve the role of `.opencode/schemas/handoff.schema.json` and `.opencode/schemas/result.schema.json` as the local canonical artifact contracts for this repo
 - Prefer additive, traceable documentation changes over informal notes scattered across files
-- Treat traceability as a first-class requirement: when a PR implements a user story, start the title with `US-###`, include `Implements: US-###` in the PR body, and update the source story in `docs/opencode-helper-cli.md` with `Status: Done` plus the PR link or number
+- Treat traceability as a first-class requirement: every implementation PR must declare a single primary user story ID (`US-###`) and follow the traceability rules in `docs/opencode-helper-cli.md` (primary story selection, multi-story handling, and when it is allowed to mark `Status: Done`).
 - For multi-agent work, keep handoffs and results traceable through the session artifact workflow under `.opencode/sessions/` and validate those artifacts against `.opencode/schemas/handoff.schema.json` and `.opencode/schemas/result.schema.json`
 - Treat helper CLI planning in `docs/opencode-helper-cli.md` as the source of truth for requirements, features, and later user stories
 - Avoid changing unrelated session artifacts under `.opencode/sessions/`

--- a/docs/opencode-helper-cli.md
+++ b/docs/opencode-helper-cli.md
@@ -596,12 +596,24 @@ User stories will be added later and must:
 - identify whether the story is user-facing, maintainer-facing, or release-engineering-facing
 
 Traceability workflow:
-- PRs that implement a user story must reference the story ID in the PR title and body.
-- PR title format: `US-###: <short title>`
-- PR body must contain a line: `Implements: US-###`
-- The implementation PR must update the corresponding story entry in this document:
-  - set `Status: Done`
-  - set `PR: [#<number>](<url>)` (preferred) or `PR: #<number>`
+- Every implementation PR must declare exactly one primary user story.
+- Primary story selection rules (in order):
+  - If the user request names a `US-###`, that is the primary story.
+  - Otherwise, choose the one story whose acceptance criteria the PR is intended to complete end-to-end.
+  - If the change spans multiple stories and none is clearly primary, split into multiple PRs (recommended) or explicitly pick a primary and list the rest as secondary (see below).
+- PR title format (primary story only): `US-###: <short title>`
+- PR body must contain a primary line: `Implements: US-###`
+- If the PR also advances other stories, include additional lines:
+  - `Also advances: US-###, US-###` (optional)
+  - Do not mark secondary stories `Done` unless their acceptance criteria are fully satisfied by this PR.
+- Updating story entries in this document:
+  - Primary story: update the story entry with the PR reference.
+    - If all acceptance criteria are satisfied, set `Status: Done`.
+    - If not all acceptance criteria are satisfied, set `Status: In progress` or `Status: In review` (choose the closest), and keep it out of `Done`.
+  - Secondary stories (if listed): only add the PR reference if the PR is intentionally tracked there; never set `Status: Done` unless fully complete.
+- PR reference format:
+  - Preferred: `PR: [#<number>](<url>)`
+  - Acceptable: `PR: #<number>`
 - Practical: if the PR number/URL is not known yet, open the PR with `PR: TBD`, then update the same PR branch before merge to replace `TBD` with the actual PR reference.
 
 ### User Stories (Iteration 1)


### PR DESCRIPTION
## Summary
- Defines a single primary `US-###` per PR plus an explicit `Also advances:` escape hatch to avoid agents guessing the wrong story.
- Tightens the rule for when `Status: Done` is allowed (only when that story’s acceptance criteria are fully met).
- Updates the PR template and `AGENTS.md` to point to the disambiguation rules.

## Files
- AGENTS.md
- docs/opencode-helper-cli.md
- .github/pull_request_template.md