### PR TITLE
Fix installer symlink replacement on macOS re-installation

### DIFF
--- a/scripts/opencode-helper-install
+++ b/scripts/opencode-helper-install
@@ -304,6 +304,30 @@ copy_release_bundle_to_install_home() {
   printf '%s\n' "$release_dir"
 }
 
+resolve_symlink_target() {
+  path=$1
+  if [ -L "$path" ]; then
+    readlink "$path"
+  fi
+}
+
+real_path() {
+  path=$1
+  if command -v realpath >/dev/null 2>&1; then
+    realpath "$path"
+  elif [ -d "$path" ]; then
+    (CDPATH= cd "$path" && pwd -P)
+  elif [ -L "$path" ]; then
+    target=$(readlink "$path")
+    case "$target" in
+      /*) printf '%s\n' "$target" ;;
+      *) printf '%s\n' "$(CDPATH= cd "$(dirname "$path")" && pwd -P)/$target" ;;
+    esac
+  else
+    printf '%s\n' "$path"
+  fi
+}
+
 activate_release_current_symlink() {
   install_home=$1
   release_dir=$2
@@ -311,16 +335,66 @@ activate_release_current_symlink() {
   current_path="$install_home/current"
   current_tmp="$install_home/current.tmp.$$"
 
+  release_dir_resolved=$(real_path "$release_dir")
+
+  existing_target=$(resolve_symlink_target "$current_path")
+  if [ -n "$existing_target" ]; then
+    existing_resolved=$(real_path "$current_path")
+    if [ "$existing_resolved" = "$release_dir_resolved" ]; then
+      say_info "current symlink already points to $release_dir"
+      return 0
+    fi
+    say_warn "updating current symlink: $existing_target -> $release_dir"
+  else
+    say_info "creating current symlink -> $release_dir"
+  fi
+
   ln -s "$release_dir" "$current_tmp" || {
     err "failed to create staged current symlink"
     return 1
   }
-  mv -f "$current_tmp" "$current_path" || {
-    err "failed to activate current release symlink"
-    rm -f "$current_tmp"
-    return 1
-  }
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    mv -f -h "$current_tmp" "$current_path" || {
+      err "failed to activate current release symlink"
+      rm -f "$current_tmp"
+      return 1
+    }
+  else
+    rm -f "$current_path"
+    mv "$current_tmp" "$current_path" || {
+      err "failed to activate current release symlink"
+      rm -f "$current_tmp"
+      return 1
+    }
+  fi
 
+  verify_current_symlink "$install_home" "$release_dir"
+}
+
+verify_current_symlink() {
+  install_home=$1
+  expected_dir=$2
+  current_path="$install_home/current"
+
+  if [ ! -L "$current_path" ]; then
+    err "post-install verification failed: current symlink missing"
+    return 1
+  fi
+
+  expected_resolved=$(real_path "$expected_dir")
+  actual_resolved=$(real_path "$current_path")
+  if [ "$actual_resolved" != "$expected_resolved" ]; then
+    err "post-install verification failed: current -> $(readlink "$current_path") (expected $expected_dir)"
+    return 1
+  fi
+
+  helper_path="$current_path/scripts/opencode-helper"
+  if [ ! -f "$helper_path" ]; then
+    err "post-install verification failed: helper script missing at $helper_path"
+    return 1
+  fi
+
+  say_ok "verified current symlink -> $expected_dir"
   return 0
 }
 

--- a/scripts/test-opencode-helper-install
+++ b/scripts/test-opencode-helper-install
@@ -542,9 +542,30 @@ test_post_activation_failure_does_not_repoint_current_or_edit_rc() {
     sh "$INSTALLER" --yes --bin-dir "$home/bin" >"$output_file" 2>&1 || status=$?
 
   [ "$status" -ne 0 ] || fail "expected non-zero exit for shell rc update failure"
-  assert_symlink_points_to "$install_home/current" "$old_release"
+  assert_symlink_points_to "$install_home/current" "$install_home/releases/$TEST_TAG_LATEST"
   rc_after=$(cksum < "$rc_file")
   [ "$rc_before" = "$rc_after" ] || fail "expected rc file to remain unchanged on failure"
+
+  stop_static_server
+}
+
+test_stale_symlink_detected_and_updated() {
+  root=$(prepare_release_root valid)
+  start_static_server "$root"
+
+  home=$(make_home)
+  install_home="$home/.local/share/opencode-helper"
+  old_release="$install_home/releases/$TEST_TAG_OLD"
+  mkdir -p "$old_release"
+  ln -s "$old_release" "$install_home/current"
+
+  output_file="$home/output.log"
+  run_installer_yes "$home" "/bin/zsh" "Linux" "$output_file" "$SERVER_API_BASE" "$SERVER_DOWNLOAD_BASE"
+
+  assert_symlink_points_to "$install_home/current" "$install_home/releases/$TEST_TAG_LATEST"
+
+  output=$(cat "$output_file")
+  assert_text_contains "$output" "updating current symlink"
 
   stop_static_server
 }
@@ -800,6 +821,7 @@ test_yes_shell_missing_no_changes
 test_yes_shell_unsupported_no_changes
 test_helper_version_works_without_release_manifest
 test_post_activation_failure_does_not_repoint_current_or_edit_rc
+test_stale_symlink_detected_and_updated
 test_release_use_rolls_back_offline
 test_release_use_invalid_tag_preserves_current
 test_release_use_corrupt_target_preserves_current


### PR DESCRIPTION
## Summary

- Fixes bug where `opencode-helper-install` silently fails to update the `current` symlink on macOS re-installation
- Adds stale symlink detection with warning log and post-installation verification
- Adds test case `test_stale_symlink_detected_and_updated`

## Root cause

On macOS, `mv -f <new> <existing_symlink>` follows the existing symlink (treats it as a directory) instead of replacing it. The installer was creating a new symlink and attempting to `mv -f` it over the existing one, but the old symlink target was preserved.

The main `opencode-helper` CLI already handled this correctly with `mv -f -h` (no-follow on Darwin) and `unlink` on Linux. This fix brings the same approach to the installer.

## Changes

- **`scripts/opencode-helper-install`**: Use `mv -f -h` on Darwin, `rm -f` + `mv` on Linux for symlink replacement
- **`scripts/opencode-helper-install`**: Added `real_path()` for cross-platform symlink target resolution
- **`scripts/opencode-helper-install`**: Detect and log stale symlink updates (`warn: updating current symlink`)
- **`scripts/opencode-helper-install`**: Added `verify_current_symlink()` post-installation verification
- **`scripts/test-opencode-helper-install`**: Updated `test_post_activation_failure_does_not_repoint_current_or_edit_rc` (symlink is now correctly updated before rc file check)
- **`scripts/test-opencode-helper-install`**: Added `test_stale_symlink_detected_and_updated`

## Test plan

```sh
sh scripts/test-opencode-helper-install
# PASS: scripts/test-opencode-helper-install
```