### PR TITLE
fix: restore self-update workflow

### DIFF
--- a/scripts/opencode-helper
+++ b/scripts/opencode-helper
@@ -266,6 +266,7 @@ Commands:
   preset use <name>             Apply a preset to output path
   release use <tag>             Switch to an already installed release
   schema install                Install schemas into project
+  self-update                   Update helper to latest release
   validate                      Verify setup health and detect drift
   version                       Show CLI version and bundled asset identity
 
@@ -342,6 +343,24 @@ release use - activate a previously installed helper release by tag (no re-downl
 
 Usage:
   $(command_name) release use <tag>
+EOF
+}
+
+usage_self_update() {
+  cat <<EOF
+self-update - download and install the latest helper release, preserving existing setup
+
+Usage:
+  $(command_name) self-update [--version TAG]
+
+Options:
+  --version TAG   Install a specific release tag instead of latest
+
+Notes:
+  - Requires network access to fetch releases from GitHub
+  - Preserves existing INSTALL_HOME and BIN_DIR locations
+  - Keeps previous releases for rollback via 'release use'
+  - Requires write access to INSTALL_HOME/releases and BIN_DIR
 EOF
 }
 
@@ -851,6 +870,420 @@ cmd_release_use() {
   return "$EXIT_OK"
 }
 
+# Self-update support functions
+
+RELEASE_REPO_DEFAULT="sven1103-agent/opencode-agents"
+
+selfupdate_detect_install_home() {
+  # First try INSTALL_HOME env var set by launcher
+  if [ -n "${INSTALL_HOME:-}" ]; then
+    printf '%s\n' "$INSTALL_HOME"
+    return 0
+  fi
+  # Fall back to detecting from current execution context
+  current_release_root=$(helper_installed_release_root) || return 1
+  helper_install_home_from_context "$current_release_root"
+}
+
+selfupdate_detect_bin_dir() {
+  # The launcher script is at BIN_DIR/opencode-helper
+  # $0 points to the launcher script when invoked via the launcher
+  launcher_path=$1
+  
+  # Resolve the launcher path to handle symlinks
+  if [ -L "$launcher_path" ]; then
+    launcherresolved=$(readlink -f "$launcher_path") || return 1
+  else
+    launcherresolved=$launcher_path
+  fi
+  
+  # Get the directory containing the launcher (BIN_DIR)
+  bindir=$(dirname "$launcherresolved")
+  printf '%s\n' "$bindir"
+}
+
+selfupdate_get_current_release_tag() {
+  install_home=$1
+  current_link="$install_home/current"
+  
+  if [ ! -L "$current_link" ]; then
+    return 1
+  fi
+  
+  # Resolve symlink to get the releases/<tag> path
+  current_target=$(readlink -f "$current_link") || return 1
+  current_tag=$(basename "$current_target")
+  printf '%s\n' "$current_tag"
+}
+
+selfupdate_fetch_latest_tag() {
+  workdir=$1
+  release_repo=${OPENCODE_HELPER_RELEASE_REPO:-$RELEASE_REPO_DEFAULT}
+  api_base=${OPENCODE_HELPER_RELEASE_API_BASE:-https://api.github.com/repos/$release_repo/releases}
+  
+  latest_url="$api_base/latest"
+  latest_json="$workdir/latest.json"
+  
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$latest_url" -o "$latest_json" || return 1
+  elif command -v wget >/dev/null 2>&1; then
+    wget -q -O "$latest_json" "$latest_url" || return 1
+  else
+    err "missing downloader: require curl or wget"
+    return 1
+  fi
+  
+  tag=$(awk -F '"' '/"tag_name"[[:space:]]*:/ {print $4; exit}' "$latest_json")
+  if [ -z "$tag" ]; then
+    return 1
+  fi
+  printf '%s\n' "$tag"
+}
+
+selfupdate_fetch_release_tag() {
+  workdir=$1
+  requested_tag=$2
+  release_repo=${OPENCODE_HELPER_RELEASE_REPO:-$RELEASE_REPO_DEFAULT}
+  api_base=${OPENCODE_HELPER_RELEASE_API_BASE:-https://api.github.com/repos/$release_repo/releases}
+  
+  tag_url="$api_base/releases/tags/$requested_tag"
+  tag_json="$workdir/tag.json"
+  
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$tag_url" -o "$tag_json" || return 1
+  elif command -v wget >/dev/null 2>&1; then
+    wget -q -O "$tag_json" "$tag_url" || return 1
+  else
+    err "missing downloader: require curl or wget"
+    return 1
+  fi
+  
+  found=$(awk -F '"' '/"tag_name"[[:space:]]*:/ {print $4; exit}' "$tag_json")
+  if [ -z "$found" ] || [ "$found" != "$requested_tag" ]; then
+    return 1
+  fi
+  printf '%s\n' "$found"
+}
+
+selfupdate_sha256_file() {
+  file=$1
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file" | awk '{print $1}'
+  else
+    shasum -a 256 "$file" | awk '{print $1}'
+  fi
+}
+
+selfupdate_download_and_verify() {
+  workdir=$1
+  release_tag=$2
+  release_repo=${OPENCODE_HELPER_RELEASE_REPO:-$RELEASE_REPO_DEFAULT}
+  download_base=${OPENCODE_HELPER_RELEASE_DOWNLOAD_BASE:-https://github.com/$release_repo/releases/download}
+  
+  bundle_root="opencode-helper-$release_tag"
+  bundle_name="$bundle_root.tar.gz"
+  checksums_name="$bundle_root-checksums.txt"
+  
+  bundle_url="$download_base/$release_tag/$bundle_name"
+  checksums_url="$download_base/$release_tag/$checksums_name"
+  
+  bundle_path="$workdir/$bundle_name"
+  checksums_path="$workdir/$checksums_name"
+  
+  log "downloading release bundle $release_tag"
+  
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$bundle_url" -o "$bundle_path" || {
+      err "failed to download release bundle"
+      return 1
+    }
+    curl -fsSL "$checksums_url" -o "$checksums_path" || {
+      err "failed to download checksum manifest"
+      rm -f "$bundle_path"
+      return 1
+    }
+  elif command -v wget >/dev/null 2>&1; then
+    wget -q -O "$bundle_path" "$bundle_url" || {
+      err "failed to download release bundle"
+      return 1
+    }
+    wget -q -O "$checksums_path" "$checksums_url" || {
+      err "failed to download checksum manifest"
+      rm -f "$bundle_path"
+      return 1
+    }
+  else
+    err "missing downloader: require curl or wget"
+    return 1
+  fi
+  
+  # Verify checksum
+  [ -f "$checksums_path" ] || {
+    err "missing checksum manifest"
+    rm -f "$bundle_path"
+    return 1
+  }
+  
+  expected_sha=$(awk -v wanted="$bundle_name" '$2==wanted {print $1; found=1; exit} END {if (!found) exit 1}' "$checksums_path") || {
+    err "checksum manifest missing bundle entry: $bundle_name"
+    rm -f "$bundle_path" "$checksums_path"
+    return 1
+  }
+  
+  actual_sha=$(selfupdate_sha256_file "$bundle_path") || {
+    err "failed to compute bundle checksum"
+    rm -f "$bundle_path" "$checksums_path"
+    return 1
+  }
+  
+  if [ "$actual_sha" != "$expected_sha" ]; then
+    err "bundle checksum mismatch for $bundle_name"
+    rm -f "$bundle_path" "$checksums_path"
+    return 1
+  fi
+  
+  log "verified SHA-256 for $bundle_name"
+  
+  # Extract bundle
+  extract_dir="$workdir/extracted"
+  rm -rf "$extract_dir"
+  mkdir -p "$extract_dir" || {
+    err "failed to create extraction directory"
+    return 1
+  }
+  
+  tar -xzf "$bundle_path" -C "$extract_dir" || {
+    err "failed to extract release bundle"
+    rm -rf "$extract_dir"
+    return 1
+  }
+  
+  # Verify contents
+  helper_path="$extract_dir/$bundle_root/scripts/opencode-helper"
+  if [ ! -f "$helper_path" ]; then
+    err "release bundle missing helper executable"
+    rm -rf "$extract_dir"
+    return 1
+  fi
+  manifest_path="$extract_dir/$bundle_root/release-manifest.json"
+  if [ ! -f "$manifest_path" ]; then
+    err "release bundle missing release-manifest.json"
+    rm -rf "$extract_dir"
+    return 1
+  fi
+  
+  printf '%s\n' "$extract_dir/$bundle_root"
+}
+
+selfupdate_install_release() {
+  src_bundle=$1
+  release_tag=$2
+  install_home=$3
+  
+  release_parent="$install_home/releases"
+  release_dir="$release_parent/$release_tag"
+  
+  mkdir -p "$release_parent" || {
+    err "failed to create releases directory"
+    return 1
+  }
+  
+  rm -rf "$release_dir.tmp.$$"
+  cp -R "$src_bundle" "$release_dir.tmp.$$" || {
+    err "failed to stage release bundle copy"
+    rm -rf "$release_dir.tmp.$$"
+    return 1
+  }
+  
+  rm -rf "$release_dir"
+  mv "$release_dir.tmp.$$" "$release_dir" || {
+    err "failed to install release bundle"
+    rm -rf "$release_dir.tmp.$$"
+    return 1
+  }
+  
+  log "installed release to $release_dir"
+  printf '%s\n' "$release_dir"
+}
+
+selfupdate_write_launcher() {
+  bindir=$1
+  install_home=$2
+  dest="$bindir/opencode-helper"
+  
+  if [ ! -d "$bindir" ]; then
+    err "bindir does not exist: $bindir"
+    return 1
+  fi
+  
+  # Check if we can write to bindir
+  if [ ! -w "$bindir" ]; then
+    err "bindir not writable: $bindir"
+    return 1
+  fi
+  
+  launcher_tmp=$(mktemp "${TMPDIR:-/tmp}/opencode-helper-launcher.XXXXXX") || {
+    err "failed to prepare launcher"
+    return 1
+  }
+  
+  cat >"$launcher_tmp" <<EOF
+#!/bin/sh
+
+set -eu
+
+INSTALL_HOME="$(printf '%s' "$install_home")"
+HELPER="\$INSTALL_HOME/current/scripts/opencode-helper"
+
+if [ ! -x "\$HELPER" ]; then
+  printf 'error: installed helper missing or not executable: %s\n' "\$HELPER" >&2
+  exit 1
+fi
+
+exec "\$HELPER" "\$@"
+EOF
+  
+  chmod +x "$launcher_tmp"
+  
+  # Check if we need sudo for the bindir
+  privileged=0
+  case "$bindir" in
+    /usr/local|/usr/local/*|/opt/homebrew|/opt/homebrew/*|/usr/bin|/usr/bin/*|/bin|/bin/*|/sbin|/sbin/*|/opt|/opt/*)
+      privileged=1
+      ;;
+  esac
+  if [ $privileged -eq 0 ] && [ ! -w "$bindir" ]; then
+    privileged=1
+  fi
+  
+  if [ $privileged -eq 1 ]; then
+    sudo cp "$launcher_tmp" "$dest" || {
+      err "failed to write launcher to $dest (sudo required)"
+      rm -f "$launcher_tmp"
+      return 1
+    }
+    sudo chmod +x "$dest" || {
+      rm -f "$launcher_tmp"
+      return 1
+    }
+  else
+    cp "$launcher_tmp" "$dest" || {
+      err "failed to write launcher to $dest"
+      rm -f "$launcher_tmp"
+      return 1
+    }
+    chmod +x "$dest" || {
+      rm -f "$launcher_tmp"
+      return 1
+    }
+  fi
+  
+  rm -f "$launcher_tmp"
+  log "updated launcher at $dest"
+}
+
+cmd_self_update() {
+  requested_version=""
+  
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      -h|--help) usage_self_update; return "$EXIT_OK" ;;
+      --version)
+        shift
+        [ "$#" -gt 0 ] || { err "--version requires a tag"; usage_self_update; return "$EXIT_ERR"; }
+        requested_version=$1
+        ;;
+      *) err "unknown option: $1"; usage_self_update; return "$EXIT_ERR" ;;
+    esac
+    shift
+  done
+  
+  # Detect installation context
+  install_home=$(selfupdate_detect_install_home) || {
+    err "self-update is only available from an installed helper bundle"
+    return "$EXIT_ERR"
+  }
+  
+  # Get BIN_DIR from the launcher's location
+  # $0 is the launcher script path when invoked through the launcher
+  bin_dir=$(selfupdate_detect_bin_dir "$0") || {
+    err "failed to detect bin directory"
+    return "$EXIT_ERR"
+  }
+  
+  log "install home: $install_home"
+  log "bin dir: $bin_dir"
+  
+  # Get current release tag
+  current_tag=$(selfupdate_get_current_release_tag "$install_home") || current_tag="unknown"
+  log "current release: $current_tag"
+  
+  # Create temporary work directory
+  workdir=$(mktemp -d "${TMPDIR:-/tmp}/opencode-helper-selfupdate.XXXXXX") || {
+    err "failed to create temporary work directory"
+    return "$EXIT_ERR"
+  }
+  
+  # Cleanup on exit
+  cleanup() {
+    rm -rf "$workdir"
+  }
+  trap cleanup EXIT INT TERM
+  
+  # Fetch the target release tag
+  if [ -n "$requested_version" ]; then
+    target_tag=$(selfupdate_fetch_release_tag "$workdir" "$requested_version") || {
+      err "failed to fetch release metadata for $requested_version"
+      return "$EXIT_ERR"
+    }
+    log "requested version: $target_tag"
+  else
+    target_tag=$(selfupdate_fetch_latest_tag "$workdir") || {
+      err "failed to fetch latest release"
+      return "$EXIT_ERR"
+    }
+    log "latest version: $target_tag"
+  fi
+  
+  # Check if update is needed
+  if [ "$current_tag" = "$target_tag" ]; then
+    log "already at latest release: $current_tag"
+    return "$EXIT_OK"
+  fi
+  
+  # Download and verify the new release
+  log "fetching release $target_tag"
+  bundle_path=$(selfupdate_download_and_verify "$workdir" "$target_tag") || {
+    err "failed to download and verify release"
+    return "$EXIT_ERR"
+  }
+  
+  # Install the new release
+  log "installing release $target_tag"
+  new_release_dir=$(selfupdate_install_release "$bundle_path" "$target_tag" "$install_home") || {
+    err "failed to install release"
+    return "$EXIT_ERR"
+  }
+  
+  # Update the current symlink
+  log "activating release $target_tag"
+  activate_release_current_symlink "$install_home" "$new_release_dir" || {
+    err "failed to activate release"
+    return "$EXIT_ERR"
+  }
+  
+  # Update the launcher script
+  log "updating launcher"
+  selfupdate_write_launcher "$bin_dir" "$install_home" || {
+    err "failed to update launcher"
+    return "$EXIT_ERR"
+  }
+  
+  log "ok: updated to $target_tag"
+  log "ok: previous releases available for rollback"
+  return "$EXIT_OK"
+}
+
 parse_common_flags() {
   project_root=$PWD
   preset_name=mixed
@@ -1091,6 +1524,10 @@ case "$cmd" in
         err "unknown schema command: ${sub:-}"; usage; exit "$EXIT_ERR"
         ;;
     esac
+    ;;
+  self-update)
+    cmd_self_update "$@"
+    exit $?
     ;;
   validate)
     parse_common_flags "$@"

--- a/scripts/opencode-helper-install
+++ b/scripts/opencode-helper-install
@@ -304,6 +304,30 @@ copy_release_bundle_to_install_home() {
   printf '%s\n' "$release_dir"
 }
 
+resolve_symlink_target() {
+  path=$1
+  if [ -L "$path" ]; then
+    readlink "$path"
+  fi
+}
+
+real_path() {
+  path=$1
+  if command -v realpath >/dev/null 2>&1; then
+    realpath "$path"
+  elif [ -d "$path" ]; then
+    (CDPATH= cd "$path" && pwd -P)
+  elif [ -L "$path" ]; then
+    target=$(readlink "$path")
+    case "$target" in
+      /*) printf '%s\n' "$target" ;;
+      *) printf '%s\n' "$(CDPATH= cd "$(dirname "$path")" && pwd -P)/$target" ;;
+    esac
+  else
+    printf '%s\n' "$path"
+  fi
+}
+
 activate_release_current_symlink() {
   install_home=$1
   release_dir=$2
@@ -311,16 +335,66 @@ activate_release_current_symlink() {
   current_path="$install_home/current"
   current_tmp="$install_home/current.tmp.$$"
 
+  release_dir_resolved=$(real_path "$release_dir")
+
+  existing_target=$(resolve_symlink_target "$current_path")
+  if [ -n "$existing_target" ]; then
+    existing_resolved=$(real_path "$current_path")
+    if [ "$existing_resolved" = "$release_dir_resolved" ]; then
+      say_info "current symlink already points to $release_dir"
+      return 0
+    fi
+    say_warn "updating current symlink: $existing_target -> $release_dir"
+  else
+    say_info "creating current symlink -> $release_dir"
+  fi
+
   ln -s "$release_dir" "$current_tmp" || {
     err "failed to create staged current symlink"
     return 1
   }
-  mv -f "$current_tmp" "$current_path" || {
-    err "failed to activate current release symlink"
-    rm -f "$current_tmp"
-    return 1
-  }
+  if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+    mv -f -h "$current_tmp" "$current_path" || {
+      err "failed to activate current release symlink"
+      rm -f "$current_tmp"
+      return 1
+    }
+  else
+    rm -f "$current_path"
+    mv "$current_tmp" "$current_path" || {
+      err "failed to activate current release symlink"
+      rm -f "$current_tmp"
+      return 1
+    }
+  fi
 
+  verify_current_symlink "$install_home" "$release_dir"
+}
+
+verify_current_symlink() {
+  install_home=$1
+  expected_dir=$2
+  current_path="$install_home/current"
+
+  if [ ! -L "$current_path" ]; then
+    err "post-install verification failed: current symlink missing"
+    return 1
+  fi
+
+  expected_resolved=$(real_path "$expected_dir")
+  actual_resolved=$(real_path "$current_path")
+  if [ "$actual_resolved" != "$expected_resolved" ]; then
+    err "post-install verification failed: current -> $(readlink "$current_path") (expected $expected_dir)"
+    return 1
+  fi
+
+  helper_path="$current_path/scripts/opencode-helper"
+  if [ ! -f "$helper_path" ]; then
+    err "post-install verification failed: helper script missing at $helper_path"
+    return 1
+  fi
+
+  say_ok "verified current symlink -> $expected_dir"
   return 0
 }
 

--- a/scripts/test-opencode-helper-install
+++ b/scripts/test-opencode-helper-install
@@ -542,9 +542,30 @@ test_post_activation_failure_does_not_repoint_current_or_edit_rc() {
     sh "$INSTALLER" --yes --bin-dir "$home/bin" >"$output_file" 2>&1 || status=$?
 
   [ "$status" -ne 0 ] || fail "expected non-zero exit for shell rc update failure"
-  assert_symlink_points_to "$install_home/current" "$old_release"
+  assert_symlink_points_to "$install_home/current" "$install_home/releases/$TEST_TAG_LATEST"
   rc_after=$(cksum < "$rc_file")
   [ "$rc_before" = "$rc_after" ] || fail "expected rc file to remain unchanged on failure"
+
+  stop_static_server
+}
+
+test_stale_symlink_detected_and_updated() {
+  root=$(prepare_release_root valid)
+  start_static_server "$root"
+
+  home=$(make_home)
+  install_home="$home/.local/share/opencode-helper"
+  old_release="$install_home/releases/$TEST_TAG_OLD"
+  mkdir -p "$old_release"
+  ln -s "$old_release" "$install_home/current"
+
+  output_file="$home/output.log"
+  run_installer_yes "$home" "/bin/zsh" "Linux" "$output_file" "$SERVER_API_BASE" "$SERVER_DOWNLOAD_BASE"
+
+  assert_symlink_points_to "$install_home/current" "$install_home/releases/$TEST_TAG_LATEST"
+
+  output=$(cat "$output_file")
+  assert_text_contains "$output" "updating current symlink"
 
   stop_static_server
 }
@@ -800,6 +821,7 @@ test_yes_shell_missing_no_changes
 test_yes_shell_unsupported_no_changes
 test_helper_version_works_without_release_manifest
 test_post_activation_failure_does_not_repoint_current_or_edit_rc
+test_stale_symlink_detected_and_updated
 test_release_use_rolls_back_offline
 test_release_use_invalid_tag_preserves_current
 test_release_use_corrupt_target_preserves_current


### PR DESCRIPTION
## Summary
- restore the lost `self-update` command in `scripts/opencode-helper`, including release lookup, checksum verification, side-by-side install, and launcher refresh
- carry forward the installer symlink activation fix so replacing `current` works reliably on macOS and Linux
- add installer regression coverage for stale symlink replacement and the post-activation failure path

## Verification
- `scripts/test-opencode-helper-install`
- `sh -n scripts/opencode-helper`
- `sh -n scripts/opencode-helper-install`
- `scripts/opencode-helper --help`