### PR TITLE
docs: mark US-029 as Done in milestone plan

### DIFF
--- a/docs/opencode-helper-v2-milestones.md
+++ b/docs/opencode-helper-v2-milestones.md
@@ -90,7 +90,7 @@ Primary stories:
 Implementation:
 - `US-027`: ✅ Merged via [PR #56](https://github.com/sven1103/opencode-agents/pull/56)
 - `US-028`: ✅ Merged via [PR #57](https://github.com/sven1103/opencode-agents/pull/57)
-- `US-029`: ⏳ Open - Not yet implemented
+- `US-029`: ✅ Done - Verified working (implemented in US-028)
 
 Why here:
 - Discovery validates that manifest parsing, source identity, and registry state all work together.


### PR DESCRIPTION
## Summary
- Mark US-029 as Done in the V2 milestone plan
- US-029 (Materialize referenced prompt files when applying a bundle) was implemented as part of US-028
- Verified both acceptance criteria work correctly:
  - AC1: Prompt files copied to `project_root/prompts/`
  - AC2: Returns EXIT_CONFLICT (4) when file exists without `--force`

## Testing
- Created test bundle with `prompt_files` in manifest
- Applied bundle and verified prompt files were copied
- Verified conflict detection works (exit code 4 without --force)