### PR TITLE
Fix self-update not extracting tarball properly

### DIFF
--- a/scripts/opencode-helper
+++ b/scripts/opencode-helper
@@ -3481,12 +3481,37 @@ selfupdate_install_release() {
     return 1
   }
   
-  rm -rf "$release_dir.tmp.$$"
-  cp -R "$src_bundle" "$release_dir.tmp.$$" || {
-    err "failed to stage release bundle copy"
+  # Handle both tarball and extracted directory
+  if [ -f "$src_bundle" ]; then
+    # It's a tarball - extract it
     rm -rf "$release_dir.tmp.$$"
+    mkdir -p "$release_dir.tmp.$$" || {
+      err "failed to create temp release directory"
+      return 1
+    }
+    tar -xf "$src_bundle" -C "$release_dir.tmp.$$" || {
+      err "failed to extract release bundle"
+      rm -rf "$release_dir.tmp.$$"
+      return 1
+    }
+    # Move the extracted contents up one level (remove the opencode-helper-VERSION prefix)
+    inner_dir=$(find "$release_dir.tmp.$$" -mindepth 1 -maxdepth 1 -type d | head -1)
+    if [ -n "$inner_dir" ]; then
+      mv "$inner_dir"/* "$release_dir.tmp.$$/" 2>/dev/null || true
+      rmdir "$inner_dir" 2>/dev/null || true
+    fi
+  elif [ -d "$src_bundle" ]; then
+    # It's already a directory - copy directly
+    rm -rf "$release_dir.tmp.$$"
+    cp -R "$src_bundle" "$release_dir.tmp.$$" || {
+      err "failed to stage release bundle copy"
+      rm -rf "$release_dir.tmp.$$"
+      return 1
+    }
+  else
+    err "invalid source bundle: $src_bundle"
     return 1
-  }
+  fi
   
   rm -rf "$release_dir"
   mv "$release_dir.tmp.$$" "$release_dir" || {


### PR DESCRIPTION
## Bug

The `self-update` command was broken - it was copying the downloaded tarball file instead of extracting its contents. This resulted in a broken installation with only a 278-byte launcher script instead of the full 121KB helper.

## Root Cause

The `selfupdate_install_release` function received the path to a `.tar.gz` file but was treating it as a directory with `cp -R`. This copied the tarball itself rather than extracting it.

## Fix

Modified `selfupdate_install_release` to:
1. Detect if the source is a tarball (file ending in `.tar.gz`) - extract it with `tar -xf`
2. Detect if it's already a directory - copy with `cp -R` (for testing/local development)
3. Handle the inner directory nesting (the tarball extracts to `opencode-helper-VERSION/`)

This ensures future self-updates work correctly.

## Status
- Critical bug fix