### PR TITLE
US-040: Add Go migration milestone plan and user stories

### DIFF
--- a/docs/opencode-helper-cli.md
+++ b/docs/opencode-helper-cli.md
@@ -11,6 +11,7 @@
   - [Non-Functional Requirements](#non-functional-requirements)
 - [First Features](#first-features)
 - [V2 Milestone Plan](opencode-helper-v2-milestones.md)
+- [Go Migration Milestone Plan](opencode-helper-go-migration-milestones.md)
 - [Traceability Matrix](#traceability-matrix)
 - [User Story Backlog Placeholder](#user-story-backlog-placeholder)
 - [Open Questions for Post-V1](#open-questions-for-post-v1)
@@ -1112,6 +1113,307 @@ Satisfies:
 | [US-037](#us-037) | User Story | [FEAT-016](#feat-016), [REQ-F-030](#req-f-030), [REQ-F-024](#req-f-024) |
 | [US-038](#us-038) | User Story | [FEAT-017](#feat-017), [REQ-F-031](#req-f-031) |
 | [US-039](#us-039) | User Story | [FEAT-018](#feat-018), [REQ-F-032](#req-f-032) |
+| [US-040](#us-040) | User Story | (Go Migration) |
+| [US-041](#us-041) | User Story | (Go Migration) |
+| [US-042](#us-042) | User Story | (Go Migration) |
+| [US-043](#us-043) | User Story | (Go Migration) |
+| [US-044](#us-044) | User Story | (Go Migration) |
+| [US-045](#us-045) | User Story | (Go Migration) |
+| [US-046](#us-046) | User Story | (Go Migration) |
+| [US-047](#us-047) | User Story | (Go Migration) |
+| [US-048](#us-048) | User Story | (Go Migration) |
+| [US-049](#us-049) | User Story | (Go Migration) |
+| [US-050](#us-050) | User Story | (Go Migration) |
+| [US-051](#us-051) | User Story | (Go Migration) |
+
+---
+
+### <a id="us-040"></a>US-040 - Set up Go project structure
+
+Priority:
+- P0
+
+Status:
+- Open
+
+Type:
+- Maintainer-facing
+
+Story:
+- As a maintainer, I want the CLI implemented in Go so that I can benefit from better JSON handling, testability, and a more robust CLI experience.
+
+Acceptance criteria:
+- Go module created with proper module path
+- Cobra CLI framework set up with root command
+- help and version subcommands work
+- Project structure follows feature-based organization
+- Dependencies: spf13/cobra, stretchr/testify, gojsonschema
+
+---
+
+### <a id="us-041"></a>US-041 - Add GitHub Actions CI
+
+Priority:
+- P1
+
+Status:
+- Open
+
+Type:
+- Maintainer-facing
+
+Related stories:
+- [US-040](#us-040)
+
+Story:
+- As a maintainer, I want automated CI so that I can catch issues early.
+
+Acceptance criteria:
+- GitHub Actions workflow runs on push/PR
+- Runs go test ./...
+- Runs go build ./...
+- Runs golangci-lint
+
+---
+
+### <a id="us-042"></a>US-042 - Implement init command
+
+Priority:
+- P0
+
+Status:
+- Open
+
+Type:
+- User-facing
+
+Related stories:
+- [US-040](#us-040)
+
+Story:
+- As a user, I want to initialize a project with a preset and schemas in one step.
+
+Acceptance criteria:
+- `opencode-helper init [--project-root PATH] [--preset NAME] [--output PATH] [--force] [--dry-run]` works
+- Copies preset file to project
+- Installs schemas to .opencode/
+- Writes helper manifest
+
+---
+
+### <a id="us-043"></a>US-043 - Implement preset list and preset use commands
+
+Priority:
+- P0
+
+Status:
+- Open
+
+Type:
+- User-facing
+
+Related stories:
+- [US-040](#us-040)
+
+Story:
+- As a user, I want to list and apply bundled presets.
+
+Acceptance criteria:
+- `opencode-helper preset list` lists all bundled presets with descriptions
+- `opencode-helper preset use <name> [--project-root PATH] [--output PATH] [--force] [--dry-run]` applies a preset
+
+---
+
+### <a id="us-044"></a>US-044 - Implement schema install and validate commands
+
+Priority:
+- P0
+
+Status:
+- Open
+
+Type:
+- User-facing
+
+Related stories:
+- [US-040](#us-040)
+
+Story:
+- As a user, I want to install and validate schemas in my project.
+
+Acceptance criteria:
+- `opencode-helper schema install [--project-root PATH] [--dry-run]` installs schemas
+- `opencode-helper schema validate [--project-root PATH]` validates installed schemas
+
+---
+
+### <a id="us-045"></a>US-045 - Implement source commands (add, list, remove)
+
+Priority:
+- P2
+
+Status:
+- Open
+
+Type:
+- User-facing
+
+Related stories:
+- [US-040](#us-040)
+
+Story:
+- As a user, I want to manage config sources.
+
+Acceptance criteria:
+- `opencode-helper source add <location> [--name NAME]` registers a source
+- `opencode-helper source list` lists registered sources
+- `opencode-helper source remove <id>` removes a source
+- Stores registry in XDG compliance location (~/.config/opencode-helper/)
+
+---
+
+### <a id="us-046"></a>US-046 - Implement bundle commands (apply, status, update)
+
+Priority:
+- P2
+
+Status:
+- Open
+
+Type:
+- User-facing
+
+Related stories:
+- [US-040](#us-040), [US-045](#us-045)
+
+Story:
+- As a user, I want to apply bundles from registered sources and track provenance.
+
+Acceptance criteria:
+- `opencode-helper bundle apply <source-id> --preset <name> [--project-root PATH] [--force] [--dry-run]` applies a preset from a bundle
+- `opencode-helper bundle status [--project-root PATH]` shows provenance
+- `opencode-helper bundle update <source-id> [--yes]` checks for and applies updates
+
+---
+
+### <a id="us-047"></a>US-047 - Implement update command
+
+Priority:
+- P2
+
+Status:
+- Open
+
+Type:
+- User-facing
+
+Related stories:
+- [US-040](#us-040)
+
+Story:
+- As a user, I want to check if a new version is available.
+
+Acceptance criteria:
+- `opencode-helper update` checks GitHub for newer version
+- Reports current version vs latest available
+- Tells user to upgrade via package manager
+
+---
+
+### <a id="us-048"></a>US-048 - Add shell completions
+
+Priority:
+- P3
+
+Status:
+- Open
+
+Type:
+- User-facing
+
+Related stories:
+- [US-040](#us-040)
+
+Story:
+- As a user, I want shell completions for faster CLI usage.
+
+Acceptance criteria:
+- `opencode-helper completion bash` generates bash completions
+- `opencode-helper completion zsh` generates zsh completions
+- `opencode-helper completion fish` generates fish completions
+
+---
+
+### <a id="us-049"></a>US-049 - Add --interactive flag for TTY mode
+
+Priority:
+- P3
+
+Status:
+- Open
+
+Type:
+- User-facing
+
+Related stories:
+- [US-040](#us-040)
+
+Story:
+- As a user, I want interactive mode for certain commands.
+
+Acceptance criteria:
+- Commands that support interactivity have --interactive flag
+- Default is non-interactive (explicit arguments required)
+- When --interactive is passed, prompts for input via TTY
+
+---
+
+### <a id="us-050"></a>US-050 - Set up goreleaser
+
+Priority:
+- P2
+
+Status:
+- Open
+
+Type:
+- Maintainer-facing
+
+Related stories:
+- [US-040](#us-040)
+
+Story:
+- As a maintainer, I want automated releases with goreleaser.
+
+Acceptance criteria:
+- .goreleaser.yaml configured
+- Creates tar.gz archives with bundled presets
+- Generates checksums
+- Integrates with GitHub releases
+
+---
+
+### <a id="us-051"></a>US-051 - Create Homebrew tap
+
+Priority:
+- P2
+
+Status:
+- Open
+
+Type:
+- User-facing
+
+Related stories:
+- [US-050](#us-050)
+
+Story:
+- As a user, I want to install via Homebrew.
+
+Acceptance criteria:
+- Homebrew tap created/updated
+- Installation via `brew install sven1103-agent/opencode-agents/opencode-helper` works
+- Formula stays up to date with releases
 
 ---
 

--- a/docs/opencode-helper-go-migration-milestones.md
+++ b/docs/opencode-helper-go-migration-milestones.md
@@ -1,0 +1,221 @@
+# OpenCode Helper CLI - Go Migration Milestone Plan
+
+## Purpose
+
+This document sequences the Go migration of the OpenCode helper CLI into implementation-sized milestones.
+
+The goal is to migrate from bash to Go for better JSON handling, testability, and CLI experience, while maintaining feature parity and enabling future improvements like Homebrew distribution.
+
+## Planning Principles
+
+- Feature-by-feature migration: implement one command at a time
+- Maintain backward compatibility in behavior (even if not exact exit codes)
+- Use modern Go practices: cobra, slog, standard library where possible
+- Prioritize user-facing commands first
+- Add polish (completions, goreleaser, Homebrew) after core functionality
+
+## Implementation Status
+
+> **Last updated**: 2026-03-28
+
+| Status | Count | Legend |
+|--------|-------|--------|
+| 🔄 In Progress | 0 | Currently being implemented |
+| ⏳ Open | 12 | Not yet started |
+
+---
+
+## Recommended Milestones
+
+### M1 - Foundation
+
+**Status**: ⏳ Open
+
+Goal:
+- Set up Go project structure with cobra scaffolding
+- Establish CI pipeline
+
+Primary stories:
+- `US-040` - Set up Go project structure
+- `US-041` - Add GitHub Actions CI
+
+Implementation:
+- `US-040`: ⏳ Open
+- `US-041`: ⏳ Open
+
+Why first:
+- Foundation must be solid before implementing commands
+- CI catches issues early in the migration
+
+Exit criteria:
+- Go module created with proper module path
+- Cobra CLI framework with root command
+- help and version subcommands work
+- Project structure follows feature-based organization
+- Dependencies: spf13/cobra, stretchr/testify, gojsonschema
+- CI runs go test, go build, golangci-lint on push/PR
+
+---
+
+### M2 - MVP Commands
+
+**Status**: ⏳ Open
+
+Goal:
+- Implement the core commands users need day-to-day
+
+Primary stories:
+- `US-042` - Implement init command
+- `US-043` - Implement preset list and preset use commands
+- `US-044` - Implement schema install and validate commands
+
+Implementation:
+- `US-042`: ⏳ Open
+- `US-043`: ⏳ Open
+- `US-044`: ⏳ Open
+
+Why next:
+- These are the commands users need most
+- Get to minimum viable product quickly
+
+Exit criteria:
+- `opencode-helper init` copies preset and installs schemas
+- `opencode-helper preset list` shows bundled presets with descriptions
+- `opencode-helper preset use <name>` applies a preset
+- `opencode-helper schema install` installs schemas to .opencode/
+- `opencode-helper schema validate` checks installed schemas
+- All commands support --dry-run, --force flags
+
+---
+
+### M3 - Extended Commands
+
+**Status**: ⏳ Open
+
+Goal:
+- Implement config source management and bundle operations
+
+Primary stories:
+- `US-045` - Implement source commands (add, list, remove)
+- `US-046` - Implement bundle commands (apply, status, update)
+- `US-047` - Implement update command
+
+Implementation:
+- `US-045`: ⏳ Open
+- `US-046`: ⏳ Open
+- `US-047`: ⏳ Open
+
+Why here:
+- These depend on MVP commands being stable
+- Source registry provides foundation for bundle operations
+
+Exit criteria:
+- `opencode-helper source add <location>` registers a config source
+- `opencode-helper source list` shows registered sources
+- `opencode-helper source remove <id>` unregisters a source
+- Registry stored in XDG compliance location (~/.config/opencode-helper/)
+- `opencode-helper bundle apply` applies preset from registered source
+- `opencode-helper bundle status` shows provenance
+- `opencode-helper bundle update` checks for and applies updates
+- `opencode-helper update` checks for new CLI version
+
+---
+
+### M4 - Polish & Distribution
+
+**Status**: ⏳ Open
+
+Goal:
+- Add polish features and prepare for distribution
+
+Primary stories:
+- `US-048` - Add shell completions
+- `US-049` - Add --interactive flag for TTY mode
+- `US-050` - Set up goreleaser
+- `US-051` - Create Homebrew tap
+
+Implementation:
+- `US-048`: ⏳ Open
+- `US-049`: ⏳ Open
+- `US-050`: ⏳ Open
+- `US-051`: ⏳ Open
+
+Why last:
+- These enhance the experience but are not required for core functionality
+- Distribution (goreleaser, Homebrew) should come after commands are stable
+
+Exit criteria:
+- Shell completions for bash, zsh, fish
+- Interactive mode with --interactive flag for relevant commands
+- goreleaser configured for automated releases
+- Homebrew tap created/updated
+
+---
+
+## Story Dependency View
+
+Foundation first:
+- `US-040` -> `US-041`
+
+MVP commands depend on foundation:
+- `US-041` -> `US-042`, `US-043`, `US-044`
+
+Extended commands depend on MVP:
+- `US-042`, `US-043`, `US-044` -> `US-045` -> `US-046` -> `US-047`
+
+Polish depends on extended:
+- `US-047` -> `US-048`, `US-049` -> `US-050` -> `US-051`
+
+---
+
+## Recommended Primary Story Order
+
+| # | Story | Status | Description |
+|---|-------|--------|-------------|
+| 1 | `US-040` | ⏳ Open | Set up Go project structure |
+| 2 | `US-041` | ⏳ Open | Add GitHub Actions CI |
+| 3 | `US-042` | ⏳ Open | Implement init command |
+| 4 | `US-043` | ⏳ Open | Implement preset list/use |
+| 5 | `US-044` | ⏳ Open | Implement schema install/validate |
+| 6 | `US-045` | ⏳ Open | Implement source commands |
+| 7 | `US-046` | ⏳ Open | Implement bundle commands |
+| 8 | `US-047` | ⏳ Open | Implement update command |
+| 9 | `US-048` | ⏳ Open | Add shell completions |
+| 10 | `US-049` | ⏳ Open | Add --interactive flag |
+| 11 | `US-050` | ⏳ Open | Set up goreleaser |
+| 12 | `US-051` | ⏳ Open | Create Homebrew tap |
+
+---
+
+## Migration Notes
+
+### What Stays in Bash
+
+The following remain in bash (maintainer-only tools):
+- Release build script (`scripts/release/build-opencode-helper-bundle.sh`)
+- Any future CI/CD automation scripts
+
+### What Changes
+
+- **Distribution**: From shell installer to Go binary + goreleaser + Homebrew
+- **Error handling**: Standard Go exit codes (0, 1, 2) instead of bash-specific codes
+- **Config storage**: XDG compliance maintained
+- **Commands**: Same commands, possibly simplified structure
+
+### What Improves
+
+- **JSON handling**: Native Go JSON libraries
+- **Testability**: Go unit tests with testify
+- **CLI experience**: Cobra's built-in help, completions, validation
+- **Cross-compilation**: Easy builds for multiple platforms via goreleaser
+- **Distribution**: Homebrew tap for easy installation
+
+---
+
+## Future Considerations (Post-Migration)
+
+After the initial Go migration, consider:
+- Adding JSON schema validation for config files (currently not in scope)
+- Supporting Windows (currently out of scope)
+- Adding auth flows for private GitHub repos
+- Implementing config file (e.g., ~/.config/opencode-helper/config.yaml) for preferences


### PR DESCRIPTION
## Summary

- Created `docs/opencode-helper-go-migration-milestones.md` - milestone sequencing for Go migration
- Added user stories US-040 through US-051 to `docs/opencode-helper-cli.md`
- Updated table of contents to link new milestone plan

## Changes

### Milestone Plan (`docs/opencode-helper-go-migration-milestones.md`)

- **M1: Foundation** - Go project setup + CI (US-040, US-041)
- **M2: MVP Commands** - Core user commands (US-042, US-043, US-044)
- **M3: Extended Commands** - Source/bundle management (US-045, US-046, US-047)
- **M4: Polish & Distribution** - Completions, goreleaser, Homebrew (US-048-US-051)

### User Stories

Added 12 user stories with:
- Priority (P0-P3)
- Type (user-facing / maintainer-facing)
- Full acceptance criteria
- Related stories

## Milestone

Go Migration: https://github.com/sven1103-agent/opencode-agents/milestone/1

Implements: US-040