### PR TITLE
chore: sync module path and install docs with oc rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# OpenCode Helper CLI
+# OpenCode Config CLI
 
 **V2 Baseline Release** - 2026.03.27
 
-This repository contains the OpenCode Helper CLI - a tool for managing OpenCode configuration bundles and schema-validated multi-agent workflows.
+This repository contains the OpenCode Config CLI (`oc`) - a tool for managing OpenCode configuration bundles and schema-validated multi-agent workflows.
 
-The helper CLI does not bundle any OpenCode configurations itself. Instead, it manages configuration bundles from external sources (like [qbicsoftware/opencode-config-bundle](https://github.com/qbicsoftware/opencode-config-bundle)) that comply with the V2 bundle contract.
+The config CLI does not bundle any OpenCode configurations itself. Instead, it manages configuration bundles from external sources (like [qbicsoftware/opencode-config-bundle](https://github.com/qbicsoftware/opencode-config-bundle)) that comply with the V2 bundle contract.
 
 ## Configuration Bundles
 
@@ -24,12 +24,12 @@ Any bundle that includes a valid `opencode-bundle.manifest.json` at its root and
 
 ## Quick Start
 
-Install the helper CLI:
+Install the config CLI:
 
 ```sh
-curl -fsSL https://github.com/sven1103-agent/opencode-agents/releases/latest/download/install.sh | sh
+curl -fsSL https://github.com/sven1103-agent/opencode-config-cli/releases/latest/download/install.sh | sh
 export PATH="$HOME/.local/bin:$PATH"
-opencode-helper version
+oc version
 ```
 
 ### Installing the Go CLI (Alpha)
@@ -40,8 +40,8 @@ For smoke testing the Go implementation, use one of:
 ```sh
 # Replace VERSION with the release tag (e.g., v0.1.0-alpha.1)
 VERSION=v0.1.0-alpha.1
-curl -L "https://github.com/sven1103-agent/opencode-agents/releases/download/${VERSION}/opencode-helper_${VERSION#v}_darwin_arm64.tar.gz" | tar xz
-mv opencode-helper ~/.local/bin/
+curl -L "https://github.com/sven1103-agent/opencode-config-cli/releases/download/${VERSION}/oc_${VERSION#v}_darwin_arm64.tar.gz" | tar xz
+mv oc ~/.local/bin/
 
 # Verify
 oc version
@@ -49,13 +49,13 @@ oc version
 
 **Build from source:**
 ```sh
-go install github.com/sven1103-agent/opencode-helper@latest
+go install github.com/sven1103-agent/opencode-config-cli@latest
 
 # Verify
 oc version
 ```
 
-> **Note:** The Go CLI binary is named `oc`, not `opencode-helper`. Run `oc --help` to see available commands.
+> **Note:** The CLI binary is `oc`.
 
 Register a config bundle and apply a preset:
 
@@ -92,7 +92,7 @@ The V2 CLI introduces **config source management** — a new way to manage your 
 oc update
 
 # Or install fresh
-curl -fsSL https://github.com/sven1103-agent/opencode-agents/releases/latest/download/install.sh | sh
+curl -fsSL https://github.com/sven1103-agent/opencode-config-cli/releases/latest/download/install.sh | sh
 ```
 
 **2. Verify upgrade:**
@@ -120,7 +120,7 @@ oc migrate legacy-config --project-root ./myproject
 
 ```sh
 # Register a GitHub release as config source
-oc source add sven1103-agent/opencode-agents --name my-config
+oc source add sven1103-agent/opencode-config-bundle --name my-config
 
 # List registered sources
 oc source list
@@ -153,18 +153,18 @@ oc bundle update <source-id>
 
 | V1 Command | V2 Equivalent |
 |------------|---------------|
-| `opencode-helper init --preset <name>` | `opencode-helper source add <repo>` + `bundle apply` |
-| `opencode-helper preset list` | `opencode-helper preset list --sources` |
-| (no equivalent) | `opencode-helper bundle status` |
-| (no equivalent) | `opencode-helper bundle update` |
-| (automatic on upgrade) | `opencode-helper migrate legacy-config` |
+| `oc init --preset <name>` | `oc source add <repo>` + `bundle apply` |
+| `oc preset list` | `oc preset list --sources` |
+| (no equivalent) | `oc bundle status` |
+| (no equivalent) | `oc bundle update` |
+| (automatic on upgrade) | `oc migrate legacy-config` |
 
 ## Install Options
 
 ### Custom install path (`--bin-dir`)
 
 ```sh
-curl -fsSL https://github.com/sven1103-agent/opencode-agents/releases/latest/download/install.sh | sh -s -- --bin-dir "$HOME/bin"
+curl -fsSL https://github.com/sven1103-agent/opencode-config-cli/releases/latest/download/install.sh | sh -s -- --bin-dir "$HOME/bin"
 export PATH="$HOME/bin:$PATH"
 oc version
 ```
@@ -172,14 +172,14 @@ oc version
 ### Version pinning (`--version` and `OPENCODE_HELPER_VERSION`)
 
 ```sh
-curl -fsSL https://github.com/sven1103-agent/opencode-agents/releases/latest/download/install.sh | sh -s -- --version v0.1.0
+curl -fsSL https://github.com/sven1103-agent/opencode-config-cli/releases/latest/download/install.sh | sh -s -- --version v0.1.0
 ```
 
 ```sh
-OPENCODE_HELPER_VERSION=v0.1.0 sh -c 'curl -fsSL https://github.com/sven1103-agent/opencode-agents/releases/latest/download/install.sh | sh'
+OPENCODE_HELPER_VERSION=v0.1.0 sh -c 'curl -fsSL https://github.com/sven1103-agent/opencode-config-cli/releases/latest/download/install.sh | sh'
 ```
 
-## Using the Installed Helper
+## Using the Installed CLI
 
 ```sh
 oc preset list

--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
-	"github.com/sven1103-agent/opencode-helper/internal/bundle"
-	"github.com/sven1103-agent/opencode-helper/internal/source"
+	"github.com/sven1103-agent/opencode-config-cli/internal/bundle"
+	"github.com/sven1103-agent/opencode-config-cli/internal/source"
 )
 
 var (

--- a/cmd/bundle_test.go
+++ b/cmd/bundle_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/sven1103-agent/opencode-helper/internal/bundle"
+	"github.com/sven1103-agent/opencode-config-cli/internal/bundle"
 )
 
 // setupTestProject creates a temporary project directory

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/sven1103-agent/opencode-helper/internal/preset"
-	"github.com/sven1103-agent/opencode-helper/internal/schema"
+	"github.com/sven1103-agent/opencode-config-cli/internal/preset"
+	"github.com/sven1103-agent/opencode-config-cli/internal/schema"
 )
 
 // validateOutputPath ensures the output path stays within the project root

--- a/cmd/preset.go
+++ b/cmd/preset.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
-	"github.com/sven1103-agent/opencode-helper/internal/preset"
+	"github.com/sven1103-agent/opencode-config-cli/internal/preset"
 )
 
 var (

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/sven1103-agent/opencode-helper/internal/version"
+	"github.com/sven1103-agent/opencode-config-cli/internal/version"
 )
 
 var versionFlag bool

--- a/cmd/source.go
+++ b/cmd/source.go
@@ -6,7 +6,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
-	"github.com/sven1103-agent/opencode-helper/internal/source"
+	"github.com/sven1103-agent/opencode-config-cli/internal/source"
 )
 
 var (

--- a/cmd/source_test.go
+++ b/cmd/source_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/sven1103-agent/opencode-helper/internal/source"
+	"github.com/sven1103-agent/opencode-config-cli/internal/source"
 )
 
 // saveRegistry saves the current registry and returns a function to restore it

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/sven1103-agent/opencode-helper/internal/version"
+	"github.com/sven1103-agent/opencode-config-cli/internal/version"
 )
 
 var versionCmd = &cobra.Command{

--- a/docs/bundle-contract.md
+++ b/docs/bundle-contract.md
@@ -1,10 +1,10 @@
 # V2 Bundle Contract
 
-This document defines the contract that configuration bundles must comply with to work with the opencode-helper CLI.
+This document defines the contract that configuration bundles must comply with to work with the `oc` CLI.
 
 ## Ownership
 
-The bundle contract is **owned by the opencode-agents repository** where the CLI lives. All schema definitions, validation rules, and contract changes are managed here.
+The bundle contract is **owned by the opencode-config-cli repository** where the CLI lives. All schema definitions, validation rules, and contract changes are managed here.
 
 Configuration bundles (like [qbicsoftware/opencode-config-bundle](https://github.com/qbicsoftware/opencode-config-bundle)) are **consumers** of this contract.
 

--- a/docs/opencode-helper-cli.md
+++ b/docs/opencode-helper-cli.md
@@ -382,7 +382,7 @@ Depends on:
 The helper CLI shall publish a standalone bootstrap install script (`install.sh`) as a separate release asset alongside the release bundle, enabling the standard `curl|sh` one-liner distribution:
 
 ```sh
-curl -fsSL https://github.com/sven1103-agent/opencode-agents/releases/latest/download/install.sh | sh
+curl -fsSL https://github.com/sven1103-agent/opencode-config-cli/releases/latest/download/install.sh | sh
 ```
 
 The bootstrap script shall:
@@ -1411,7 +1411,7 @@ Story:
 
 Acceptance criteria:
 - Homebrew tap created/updated
-- Installation via `brew install sven1103-agent/opencode-agents/opencode-helper` works
+- Installation via `brew install sven1103-agent/opencode-config-cli/oc` works
 - Formula stays up to date with releases
 
 ---
@@ -2136,7 +2136,7 @@ Story:
 - As a developer, I want to install `opencode-helper` with a single `curl|sh` command without cloning the repository, so that getting started with the helper CLI is frictionless.
 
 Acceptance criteria:
-- Given a macOS or Linux system with `curl` or `wget` available, when I run `curl -fsSL https://github.com/sven1103-agent/opencode-agents/releases/latest/download/install.sh | sh`, then `opencode-helper` is installed to `~/.local/bin/opencode-helper` and the helper is on `PATH`.
+- Given a macOS or Linux system with `curl` or `wget` available, when I run `curl -fsSL https://github.com/sven1103-agent/opencode-config-cli/releases/latest/download/install.sh | sh`, then `opencode-helper` is installed to `~/.local/bin/opencode-helper` and the helper is on `PATH`.
 - Given the bootstrap install script, when I run `curl .../install.sh | sh --version v1.0.0`, then the installed helper is from that exact release tag.
 - Given the bootstrap install script, when the downloaded `opencode-helper-install` fails its checksum verification, then the bootstrap exits non-zero without executing the installer.
 - Given `OPENCODE_HELPER_VERSION` is set in the environment, when the bootstrap runs, then it uses that tag instead of `latest`.

--- a/docs/opencode-helper-v2-milestones.md
+++ b/docs/opencode-helper-v2-milestones.md
@@ -68,7 +68,7 @@ This is the initial V2 baseline release with full config-source management suppo
 opencode-helper self-update
 
 # Or fresh install
-curl -fsSL https://github.com/sven1103-agent/opencode-agents/releases/latest/download/install.sh | sh
+curl -fsSL https://github.com/sven1103-agent/opencode-config-cli/releases/latest/download/install.sh | sh
 
 # For existing V1 projects, migration is optional
 opencode-helper migrate legacy-config --project-root ./myproject

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/sven1103-agent/opencode-helper
+module github.com/sven1103-agent/opencode-config-cli
 
 go 1.21
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,6 +1,6 @@
-// Package version provides version information for opencode-helper.
+// Package version provides version information for oc.
 package version
 
-// Version is the current version of opencode-helper.
+// Version is the current version of oc.
 // Set at build time via -ldflags.
 var Version = "0.0.0-dev"

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/sven1103-agent/opencode-helper/cmd"
+	"github.com/sven1103-agent/opencode-config-cli/cmd"
 )
 
 func main() {

--- a/scripts/opencode-helper
+++ b/scripts/opencode-helper
@@ -3280,7 +3280,7 @@ cmd_release_use() {
 
 # Self-update support functions
 
-RELEASE_REPO_DEFAULT="sven1103-agent/opencode-agents"
+RELEASE_REPO_DEFAULT="sven1103-agent/opencode-config-cli"
 
 selfupdate_detect_install_home() {
   # First try INSTALL_HOME env var set by launcher
@@ -3740,7 +3740,7 @@ cmd_update() {
     log "Current version: $HELPER_VERSION"
     log ""
     log "Note: This appears to be a development or direct installation."
-    log "To check for updates, visit: https://github.com/sven1103-agent/opencode-helper/releases"
+    log "To check for updates, visit: https://github.com/sven1103-agent/opencode-config-cli/releases"
     return "$EXIT_OK"
   fi
 
@@ -3758,7 +3758,7 @@ cmd_update() {
   latest_tag=$(selfupdate_fetch_latest_tag "$workdir") || {
     log "Current version: $current_tag"
     log ""
-    err "Failed to check for updates. Please visit: https://github.com/sven1103-agent/opencode-helper/releases"
+    err "Failed to check for updates. Please visit: https://github.com/sven1103-agent/opencode-config-cli/releases"
     return "$EXIT_ERR"
   }
 
@@ -3785,7 +3785,7 @@ cmd_update() {
     log "    brew upgrade opencode-helper"
     log ""
     log "  Or reinstall using the install script:"
-    log "    curl -fsSL https://github.com/sven1103-agent/opencode-agents/releases/latest/download/install.sh | sh"
+    log "    curl -fsSL https://github.com/sven1103-agent/opencode-config-cli/releases/latest/download/install.sh | sh"
     log ""
     log "  Or use self-update (if installed via bundle):"
     log "    opencode-helper self-update"

--- a/scripts/opencode-helper-install
+++ b/scripts/opencode-helper-install
@@ -5,7 +5,7 @@ set -eu
 BEGIN_SENTINEL="# opencode-helper: BEGIN managed PATH"
 END_SENTINEL="# opencode-helper: END managed PATH"
 
-RELEASE_REPO_DEFAULT="sven1103-agent/opencode-agents"
+RELEASE_REPO_DEFAULT="sven1103-agent/opencode-config-cli"
 INSTALL_WORK_DIR=
 FETCHED_HELPER_PATH=
 FETCHED_BUNDLE_PATH=

--- a/scripts/release/install.sh
+++ b/scripts/release/install.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-RELEASE_REPO_DEFAULT="sven1103-agent/opencode-agents"
+RELEASE_REPO_DEFAULT="sven1103-agent/opencode-config-cli"
 
 RELEASE_REPO=${OPENCODE_HELPER_RELEASE_REPO:-$RELEASE_REPO_DEFAULT}
 API_BASE=${OPENCODE_HELPER_API_BASE:-https://api.github.com/repos/$RELEASE_REPO/releases}
@@ -27,7 +27,7 @@ Options:
 
 Environment:
   OPENCODE_HELPER_VERSION         Pin the release tag (overrides latest)
-  OPENCODE_HELPER_RELEASE_REPO    Override release repo (default: sven1103-agent/opencode-agents)
+  OPENCODE_HELPER_RELEASE_REPO    Override release repo (default: sven1103-agent/opencode-config-cli)
 EOF
 }
 


### PR DESCRIPTION
## Summary
- update the Go module path and imports to `github.com/sven1103-agent/opencode-config-cli`
- align install docs and release installer defaults with the renamed repository and the `oc` CLI name
- refresh active package manager and bootstrap examples so `go install` and release installs point at the current slug