### PR TITLE
fix: publish goreleaser releases to renamed repo

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -41,7 +41,7 @@ changelog:
 release:
   github:
     owner: sven1103-agent
-    name: opencode-agents
+    name: opencode-config-cli
   draft: false
   prerelease: auto
   name_template: "{{.Tag}}"


### PR DESCRIPTION
## Summary
- update GoReleaser's GitHub release target from `sven1103-agent/opencode-agents` to `sven1103-agent/opencode-config-cli`
- unblock release asset uploads after the repository rename
- keep the fix minimal to reduce release risk