### PR TITLE
chore: add lightweight prerelease feedback workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Releases
+    url: https://github.com/sven1103-agent/opencode-config-cli/releases
+    about: Try the latest prerelease and report issues here

--- a/.github/ISSUE_TEMPLATE/prerelease-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/prerelease-bug-report.md
@@ -1,0 +1,29 @@
+---
+name: Prerelease bug report
+about: Report a bug found while smoke-testing a prerelease
+title: "[Bug] "
+labels: bug, prerelease-feedback
+assignees: ""
+---
+
+## Version
+<!-- e.g. v1.0.0-alpha.3 -->
+
+## Environment
+- OS:
+- Shell:
+- Install method:
+
+## What I ran
+```sh
+paste command here
+```
+
+## Expected behavior
+
+## Actual behavior
+
+## Steps to reproduce
+
+## Notes
+<!-- optional logs, screenshots, extra context -->

--- a/README.md
+++ b/README.md
@@ -67,6 +67,26 @@ oc source add qbicsoftware/opencode-config-bundle --name qbic
 oc bundle apply qbic --preset mixed --project-root .
 ```
 
+## Prerelease Feedback
+
+Please smoke-test prereleases and open a GitHub issue if you find a problem.
+
+When reporting a prerelease issue, include:
+
+- the prerelease version tested
+- OS and shell
+- install method
+- command run
+- expected behavior
+- actual behavior
+- reproduction steps
+
+Maintainer triage stays lightweight:
+
+- all feedback is welcome as normal GitHub issues
+- only maintainer-approved issues are added to milestone `1.0.0`
+- only clear GA blockers get the `release:blocker` label
+
 ## Upgrading to V2 (Config Source Management)
 
 The V2 CLI introduces **config source management** — a new way to manage your OpenCode configuration using registered sources instead of bundled presets.

--- a/docs/opencode-helper-cli.md
+++ b/docs/opencode-helper-cli.md
@@ -4,6 +4,7 @@
 
 - [Overview](#overview)
 - [Decision Log](#decision-log)
+- [Release Intake](#release-intake)
 - [PRD](#prd)
 - [Scope](#scope)
 - [Requirements](#requirements)
@@ -64,6 +65,33 @@ The helper CLI remains the supported installer/applier:
 Interaction with DEC-001:
 - DEC-001 remains the V1 baseline.
 - DEC-002 supersedes DEC-001 for V2+ scope.
+
+---
+
+## Release Intake
+
+### <a id="release-intake-001"></a>Release Intake For 1.0.0
+
+The `1.0.0` GitHub milestone is the sole curated release todo list for general availability.
+
+Lightweight maintainer process:
+
+- prerelease testers are encouraged to open normal GitHub issues for any bug or rough edge they find
+- the repository provides a small prerelease bug report issue template to make reports easier to reproduce
+- only the maintainer assigns issues to milestone `1.0.0`
+- only issues that must land before GA are added to milestone `1.0.0`
+- only clear GA blockers receive the `release:blocker` label
+- valid but non-GA issues may remain outside the milestone or receive `release:post-1.0.0`
+
+Prerelease release notes should include a short call for smoke testing and issue filing, asking reporters to provide:
+
+- prerelease version tested
+- OS and shell
+- install method
+- command run
+- expected behavior
+- actual behavior
+- reproduction steps
 
 ---
 


### PR DESCRIPTION
## Summary
- add a small GitHub issue template for prerelease bug reports
- document a lightweight `1.0.0` release intake and triage process in the repo docs
- support solo-maintainer release tracking with the new `1.0.0` milestone and release labels