### PR TITLE
feat: add guided shell completion command with user instructions

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var completionCmd = &cobra.Command{
+	Use:   "completion [shell]",
+	Short: "Generate shell completion scripts",
+	Long: `Generate the autocompletion script for oc for the specified shell.
+
+To load completions:
+
+Bash:
+
+  $ source <(oc completion bash)
+
+  # To load completions for each session, execute once:
+  # Linux:
+  $ oc completion bash > /etc/bash_completion.d/oc
+  # macOS:
+  $ oc completion bash > /usr/local/etc/bash_completion.d/oc
+
+Zsh:
+
+  # If shell completion is not already enabled in your environment,
+  # you will need to enable it.  You can execute the following once:
+
+  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+  # To load completions for each session, execute once:
+  $ oc completion zsh > "${fpath[1]}/_oc"
+
+  # You will need to start a new shell for this setup to take effect.
+
+Fish:
+
+  $ oc completion fish | source
+
+  # To load completions for each session, execute once:
+  $ oc completion fish > ~/.config/fish/completions/oc.fish
+
+PowerShell:
+
+  $ oc completion powershell | Out-String | Invoke-Expression
+
+  # To load completions for every session, add the output of the above command
+  # to your PowerShell profile.
+`,
+	DisableFlagsInUseLine: true,
+	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+	Args:                  cobra.ExactValidArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		switch args[0] {
+		case "bash":
+			return rootCmd.GenBashCompletion(os.Stdout)
+		case "zsh":
+			return rootCmd.GenZshCompletion(os.Stdout)
+		case "fish":
+			return rootCmd.GenFishCompletion(os.Stdout, true)
+		case "powershell":
+			return rootCmd.GenPowerShellCompletionWithDesc(os.Stdout)
+		}
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(completionCmd)
+}


### PR DESCRIPTION
## Summary
- Adds a custom `oc completion` command that provides clear user guidance on how to install shell completions for bash, zsh, fish, and PowerShell
- Addresses US-048: users were previously shown raw completion script output without instructions

## Changes
- New `cmd/completion.go` file with custom completion command
- Long description includes usage instructions for each shell:
  - Temporary loading (`source <(oc completion bash)`)
  - Persistent installation (e.g., `/etc/bash_completion.d/oc`, `${fpath[1]}/_oc`)
  - Shell-specific setup steps

## Testing
- All existing tests pass (`go test ./...`)
- Manually verified `oc completion --help` shows guidance
- Manually verified `oc completion bash|zsh|fish|powershell` generates valid scripts