### PR TITLE
fix: correct ldflags path and binary name for v1.0.0-alpha.3 release

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,15 +4,15 @@
 
 version: 2
 
-project_name: opencode-helper
+project_name: oc
 
 before:
   hooks:
     - go mod tidy
 
 builds:
-  - id: opencode-helper
-    binary: opencode-helper
+    - id: oc
+    binary: oc
     main: ./main.go
     env:
       - CGO_ENABLED=0
@@ -28,7 +28,7 @@ builds:
         goarch: arm64
     ldflags:
       - -s -w
-      - -X github.com/sven1103-agent/opencode-helper/internal/version.Version={{.Version}}
+      - -X github.com/sven1103-agent/opencode-config-cli/internal/version.Version={{.Version}}
 
 changelog:
   sort: desc


### PR DESCRIPTION
## Summary
- Fixes issue #111 - version command shows wrong CLI version
- Updates .goreleaser.yaml to use correct module path for version injection
- Changes binary name from opencode-helper to oc

## Changes
- ldflags path: `github.com/sven1103-agent/opencode-helper/internal/version.Version` → `github.com/sven1103-agent/opencode-config-cli/internal/version.Version`
- project_name: `opencode-helper` → `oc`
- binary: `opencode-helper` → `oc`

## Verification
After merge and new release, `oc version` should display the correct version instead of "0.0.0-dev"