### PR TITLE
US-052: add CLI e2e workflow and binary coverage

### DIFF
--- a/.github/workflows/e2e-cli.yml
+++ b/.github/workflows/e2e-cli.yml
@@ -1,0 +1,44 @@
+name: E2E CLI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: e2e-cli-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e-cli:
+    name: E2E CLI (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+          cache: true
+
+      - name: Create build directory
+        run: mkdir -p .tmp
+
+      - name: Build CLI
+        run: go build -o .tmp/oc .
+
+      - name: Run E2E tests
+        run: go test ./e2e -v
+        env:
+          OC_E2E_BINARY: ${{ github.workspace }}/.tmp/oc

--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/sven1103-agent/opencode-config-cli/internal/bundle"
+	configpreset "github.com/sven1103-agent/opencode-config-cli/internal/preset"
 	"github.com/sven1103-agent/opencode-config-cli/internal/source"
 )
 
@@ -146,7 +147,7 @@ func runBundleApply(sourceID string) error {
 	}
 
 	// Get preset from manifest
-	preset, err := bundle.GetPreset(manifest, bundlePreset)
+	bundlePresetEntry, err := bundle.GetPreset(manifest, bundlePreset)
 	if err != nil {
 		return fmt.Errorf("preset not found in bundle: %s", bundlePreset)
 	}
@@ -160,7 +161,7 @@ func runBundleApply(sourceID string) error {
 	}
 
 	// Read preset content
-	presetFilePath := filepath.Join(bundleRoot, preset.Entrypoint)
+	presetFilePath := filepath.Join(bundleRoot, bundlePresetEntry.Entrypoint)
 	presetContent, err := os.ReadFile(presetFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to read preset file: %w", err)
@@ -173,11 +174,8 @@ func runBundleApply(sourceID string) error {
 		return nil
 	}
 
-	// Write config file
-	if err := os.WriteFile(outputPath, presetContent, 0644); err != nil {
-		if !bundleForce && os.IsExist(err) {
-			return fmt.Errorf("output file exists: %s (use --force to overwrite)", outputPath)
-		}
+	// Reuse the shared write semantics so bundle apply matches init/preset overwrite behavior.
+	if err := configpreset.WriteConfig(outputPath, string(presetContent), bundleForce); err != nil {
 		return fmt.Errorf("failed to write config: %w", err)
 	}
 	fmt.Printf("written: %s\n", outputPath)
@@ -189,7 +187,7 @@ func runBundleApply(sourceID string) error {
 		SourceType:    string(src.Type),
 		BundleVersion: manifest.BundleVersion,
 		PresetName:    bundlePreset,
-		Entrypoint:    preset.Entrypoint,
+		Entrypoint:    bundlePresetEntry.Entrypoint,
 		AppliedAt:     "2026-03-31T00:00:00Z", // Would use time.Now().Format(time.RFC3339)
 	}
 

--- a/docs/cli-e2e-coverage.md
+++ b/docs/cli-e2e-coverage.md
@@ -1,0 +1,84 @@
+# CLI E2E Coverage
+
+## Purpose
+
+This document tracks black-box end-to-end coverage for the shipped Go CLI binary (`oc`).
+
+It is the durable inventory for what is already covered, what is verified in CI, and what is still deferred.
+
+## Scope
+
+- Test the built `oc` binary, not internal package functions
+- Focus on deterministic, offline scenarios first
+- Track both happy paths and operator-facing failure paths
+- Keep coverage aligned with supported Linux and macOS release targets
+
+## Principles
+
+- Run tests against the compiled binary via `os/exec`
+- Isolate each test with temp directories and isolated user config state
+- Keep fixtures local and deterministic
+- Avoid live network dependencies in CI
+- Expand coverage incrementally and update this document in the same PR
+
+## Workflow
+
+- Workflow file: `.github/workflows/e2e-cli.yml`
+- Binary handoff env var: `OC_E2E_BINARY`
+- Current CI platforms:
+  - `ubuntu-latest`
+  - `macos-latest`
+
+## Test Harness
+
+- Package: `e2e/`
+- Fixture root: `e2e/testdata/`
+- Execution model:
+  - build `oc`
+  - invoke commands via subprocesses
+  - set isolated `HOME` and `XDG_CONFIG_HOME`
+  - verify stdout, stderr, exit status, and written files
+
+## Covered Scenarios
+
+| Scenario | Command(s) | Source Type | Status | CI Verified | Notes |
+|---|---|---|---|---|---|
+| Print version | `oc version` | n/a | Implemented | No | Verifies built binary launches and prints version |
+| Register local directory source | `oc source add <dir>` | local directory | Implemented | No | Uses fixture bundle with manifest |
+| Register local archive source | `oc source add <tar.gz>` | local archive | Implemented | No | Archive generated at test runtime |
+| List registered sources | `oc source list` | registry | Implemented | No | Confirms isolated registry contents |
+| Apply preset from local directory source | `oc bundle apply <id> --preset <name>` | local directory | Implemented | No | Verifies written config and provenance |
+| Apply preset from local archive source | `oc bundle apply <id> --preset <name>` | local archive | Implemented | No | Exercises tar extraction path |
+| Show applied bundle provenance | `oc bundle status --project-root <dir>` | project provenance | Implemented | No | Reads `.opencode/bundle-provenance.json` through CLI |
+| Refuse overwrite without force | `oc bundle apply <id> --preset <name>` | local directory | Implemented | No | Must fail when output already exists |
+| Reject missing manifest source | `oc source add <dir>` | invalid local directory | Implemented | No | Validates manifest presence check |
+| Reject invalid tarball | `oc source add <tar.gz>` and/or `oc bundle apply <id> --preset <name>` | invalid local archive | Implemented | No | Verifies archive extraction failure path |
+| Reject unknown source ID | `oc bundle apply <id> --preset <name>` | registry lookup | Implemented | No | Verifies user-facing error path |
+
+## Deferred Scenarios
+
+| Gap | Reason | Planned Follow-up |
+|---|---|---|
+| GitHub release source E2E | Current implementation still has remote operations marked not implemented in this branch line | Add once remote source behavior is stable end to end |
+| `httptest`-backed remote source coverage | Not needed for initial local-flow milestone | Add with remote-source implementation follow-up |
+| `bundle update` E2E | Current command behavior is intentionally limited and network-dependent | Add when update behavior is production-ready |
+| Windows runner coverage | Windows is out of current scope | Revisit only if product scope changes |
+
+## Fixture Strategy
+
+- Keep a small valid local bundle fixture in `e2e/testdata/fixture-bundle/`
+- Generate `.tar.gz` archives during test execution instead of committing binary archives
+- Keep invalid cases lightweight and explicit
+
+## Environment Isolation
+
+- Each test uses a fresh temporary project root
+- Each test uses a fresh temporary config home
+- Subprocess env sets:
+  - `HOME`
+  - `XDG_CONFIG_HOME`
+
+## Change Log
+
+- 2026-04-01: Document created for `US-052` initial local-flow coverage planning
+- 2026-04-01: Initial local-flow scenarios implemented in `e2e/` and wired into `.github/workflows/e2e-cli.yml`

--- a/docs/opencode-helper-cli.md
+++ b/docs/opencode-helper-cli.md
@@ -1153,6 +1153,7 @@ Satisfies:
 | [US-049](#us-049) | User Story | (Go Migration) |
 | [US-050](#us-050) | User Story | (Go Migration) |
 | [US-051](#us-051) | User Story | (Go Migration) |
+| [US-052](#us-052) | User Story | (Go Migration) |
 
 ---
 
@@ -1441,6 +1442,34 @@ Acceptance criteria:
 - Homebrew tap created/updated
 - Installation via `brew install sven1103-agent/opencode-config-cli/oc` works
 - Formula stays up to date with releases
+
+---
+
+### <a id="us-052"></a>US-052 - Add CI-backed end-to-end coverage for the Go CLI
+
+Priority:
+- P1
+
+Status:
+- Open
+
+Type:
+- Release-engineering-facing
+
+Related stories:
+- [US-041](#us-041)
+- [US-045](#us-045)
+- [US-046](#us-046)
+
+Story:
+- As a maintainer, I want CI to execute black-box tests against the built `oc` binary so that shipped command wiring, filesystem behavior, and user-facing flows are validated before merge.
+
+Acceptance criteria:
+- A dedicated GitHub Actions workflow builds `oc` and runs CLI E2E tests on push and pull request.
+- E2E tests execute the compiled binary via `os/exec` instead of calling command internals directly.
+- The workflow runs on `ubuntu-latest` and `macos-latest`.
+- Initial E2E coverage includes `version`, local source registration, local bundle apply, local archive apply, provenance status, and key offline failure paths.
+- Covered and deferred scenarios are tracked in a dedicated E2E coverage reference document.
 
 ---
 

--- a/docs/opencode-helper-go-migration-milestones.md
+++ b/docs/opencode-helper-go-migration-milestones.md
@@ -16,13 +16,13 @@ The goal is to migrate from bash to Go for better JSON handling, testability, an
 
 ## Implementation Status
 
-> **Last updated**: 2026-03-31
+> **Last updated**: 2026-04-01
 
 | Status | Count | Legend |
 |--------|-------|--------|
 | ✅ Done | 8 | Completed and merged |
 | ❌ Out of Scope | 1 | Not applicable to CLI |
-| ⏳ Open | 3 | Not yet started |
+| ⏳ Open | 4 | Not yet started |
 
 ---
 
@@ -122,34 +122,41 @@ Exit criteria:
 
 ---
 
-### M4 - Polish & Distribution
+### M4 - Polish, Distribution, and Coverage
 
 **Status**: 🔄 In Progress
 
 Goal:
-- Add polish features and prepare for distribution
+- Add polish features, release distribution, and shipped-binary coverage
 
 Primary stories:
 - `US-048` - Add shell completions
 - `US-049` - Add --interactive flag for TTY mode
 - `US-050` - Set up goreleaser
 - `US-051` - Create Homebrew tap
+- `US-052` - Add CI-backed end-to-end coverage for the Go CLI
 
 Implementation:
 - `US-048`: ⏳ Open
 - `US-049`: ⏳ Open
 - `US-050`: ✅ Done (PR #90)
 - `US-051`: ⏳ Open
+- `US-052`: ⏳ Open
 
 Why last:
 - These enhance the experience but are not required for core functionality
 - Distribution (goreleaser, Homebrew) should come after commands are stable
+- Black-box coverage should validate the shipped `oc` binary after command behavior is stable
 
 Exit criteria:
 - Shell completions for bash, zsh, fish
 - Interactive mode with --interactive flag for relevant commands
 - goreleaser configured for automated releases
 - Homebrew tap created/updated
+- Dedicated GitHub Actions workflow builds `oc` and runs black-box E2E tests
+- E2E workflow runs on Linux and macOS
+- E2E tests cover local directory and local archive source flows
+- E2E coverage inventory is documented and kept current
 
 ---
 
@@ -166,6 +173,9 @@ Extended commands depend on MVP:
 
 Polish depends on extended:
 - `US-047` -> `US-048`, `US-049` -> `US-050` -> `US-051`
+
+Shipped-binary coverage depends on core command stability:
+- `US-045`, `US-046` -> `US-052`
 
 ---
 
@@ -187,6 +197,7 @@ Polish depends on extended:
 | 10 | `US-049` | ⏳ Open | Add --interactive flag |
 | 11 | `US-050` | ✅ Done | Set up goreleaser (PR #90) |
 | 12 | `US-051` | ⏳ Open | Create Homebrew tap |
+| 13 | `US-052` | ⏳ Open | Add CI-backed end-to-end coverage for the Go CLI |
 
 ---
 

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -1,0 +1,344 @@
+package e2e
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+type commandResult struct {
+	stdout string
+	stderr string
+	err    error
+}
+
+type provenance struct {
+	SourceID      string `json:"source_id"`
+	SourceName    string `json:"source_name"`
+	SourceType    string `json:"source_type"`
+	BundleVersion string `json:"bundle_version"`
+	PresetName    string `json:"preset_name"`
+	Entrypoint    string `json:"entrypoint"`
+	AppliedAt     string `json:"applied_at"`
+}
+
+func TestVersion(t *testing.T) {
+	result := runOC(t, testEnv(t), "version")
+	requireSuccess(t, result)
+	if !strings.HasPrefix(result.stdout, "oc ") {
+		t.Fatalf("expected version output, got stdout=%q stderr=%q", result.stdout, result.stderr)
+	}
+}
+
+func TestLocalDirectoryFlow(t *testing.T) {
+	env := testEnv(t)
+	bundleDir := copyFixtureBundle(t)
+	projectRoot := t.TempDir()
+
+	addResult := runOC(t, env, "source", "add", bundleDir, "--name", "fixture-dir")
+	requireSuccess(t, addResult)
+	sourceID := extractSourceID(t, addResult.stdout)
+
+	listResult := runOC(t, env, "source", "list")
+	requireSuccess(t, listResult)
+	requireContains(t, listResult.stdout, sourceID)
+	requireContains(t, listResult.stdout, "fixture-dir")
+	requireContains(t, listResult.stdout, "local-directory")
+
+	applyResult := runOC(t, env, "bundle", "apply", sourceID, "--preset", "fixture", "--project-root", projectRoot)
+	requireSuccess(t, applyResult)
+
+	configPath := filepath.Join(projectRoot, "opencode.json")
+	configData, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("failed to read applied config: %v", err)
+	}
+	requireContains(t, string(configData), `"mode": "fixture"`)
+
+	provenancePath := filepath.Join(projectRoot, ".opencode", "bundle-provenance.json")
+	prov := readProvenance(t, provenancePath)
+	if prov.SourceID != sourceID {
+		t.Fatalf("expected source id %q, got %q", sourceID, prov.SourceID)
+	}
+	if prov.SourceType != "local-directory" {
+		t.Fatalf("expected source type local-directory, got %q", prov.SourceType)
+	}
+	if prov.PresetName != "fixture" {
+		t.Fatalf("expected preset fixture, got %q", prov.PresetName)
+	}
+
+	statusResult := runOC(t, env, "bundle", "status", "--project-root", projectRoot)
+	requireSuccess(t, statusResult)
+	requireContains(t, statusResult.stdout, "Bundle Provenance:")
+	requireContains(t, statusResult.stdout, sourceID)
+	requireContains(t, statusResult.stdout, "fixture-dir")
+	requireContains(t, statusResult.stdout, "fixture")
+
+	overwriteResult := runOC(t, env, "bundle", "apply", sourceID, "--preset", "fixture", "--project-root", projectRoot)
+	requireFailure(t, overwriteResult)
+	requireContains(t, overwriteResult.stderr, "output file exists")
+
+	forceResult := runOC(t, env, "bundle", "apply", sourceID, "--preset", "fixture", "--project-root", projectRoot, "--force")
+	requireSuccess(t, forceResult)
+	updatedProv := readProvenance(t, provenancePath)
+	if updatedProv.SourceID != sourceID {
+		t.Fatalf("expected forced apply to preserve source id %q, got %q", sourceID, updatedProv.SourceID)
+	}
+	if updatedProv.SourceName != "fixture-dir" {
+		t.Fatalf("expected forced apply source name fixture-dir, got %q", updatedProv.SourceName)
+	}
+}
+
+func TestLocalArchiveFlow(t *testing.T) {
+	env := testEnv(t)
+	bundleDir := copyFixtureBundle(t)
+	archivePath := filepath.Join(t.TempDir(), "fixture-bundle.tar.gz")
+	createTarGzFromDir(t, bundleDir, archivePath)
+	projectRoot := t.TempDir()
+
+	addResult := runOC(t, env, "source", "add", archivePath, "--name", "fixture-archive")
+	requireSuccess(t, addResult)
+	sourceID := extractSourceID(t, addResult.stdout)
+
+	applyResult := runOC(t, env, "bundle", "apply", sourceID, "--preset", "fixture", "--project-root", projectRoot)
+	requireSuccess(t, applyResult)
+
+	provenancePath := filepath.Join(projectRoot, ".opencode", "bundle-provenance.json")
+	prov := readProvenance(t, provenancePath)
+	if prov.SourceType != "local-archive" {
+		t.Fatalf("expected source type local-archive, got %q", prov.SourceType)
+	}
+	if prov.SourceName != "fixture-archive" {
+		t.Fatalf("expected source name fixture-archive, got %q", prov.SourceName)
+	}
+}
+
+func TestBundleApplyFailsForUnknownSource(t *testing.T) {
+	projectRoot := t.TempDir()
+	result := runOC(t, testEnv(t), "bundle", "apply", "missing-id", "--preset", "fixture", "--project-root", projectRoot)
+	requireFailure(t, result)
+	requireContains(t, result.stderr, "source not found")
+}
+
+func TestSourceAddFailsWithoutManifest(t *testing.T) {
+	bundleDir := t.TempDir()
+	result := runOC(t, testEnv(t), "source", "add", bundleDir)
+	requireFailure(t, result)
+	requireContains(t, result.stderr, "bundle manifest not found")
+}
+
+func TestInvalidTarballFailsOnApply(t *testing.T) {
+	env := testEnv(t)
+	archivePath := filepath.Join(t.TempDir(), "invalid.tar.gz")
+	if err := os.WriteFile(archivePath, []byte("not a tarball"), 0o644); err != nil {
+		t.Fatalf("failed to write invalid archive: %v", err)
+	}
+
+	addResult := runOC(t, env, "source", "add", archivePath, "--name", "broken-archive")
+	requireSuccess(t, addResult)
+	sourceID := extractSourceID(t, addResult.stdout)
+
+	projectRoot := t.TempDir()
+	applyResult := runOC(t, env, "bundle", "apply", sourceID, "--preset", "fixture", "--project-root", projectRoot)
+	requireFailure(t, applyResult)
+	requireContains(t, applyResult.stderr, "failed to resolve source")
+	if runtime.GOOS == "darwin" {
+		requireContains(t, applyResult.stderr, "failed to extract tarball")
+		return
+	}
+	requireContains(t, applyResult.stderr, "failed to extract tarball")
+}
+
+func testEnv(t *testing.T) []string {
+	t.Helper()
+	homeDir := t.TempDir()
+	configHome := filepath.Join(homeDir, ".config")
+	if err := os.MkdirAll(configHome, 0o755); err != nil {
+		t.Fatalf("failed to create config home: %v", err)
+	}
+
+	pathValue := os.Getenv("PATH")
+	if pathValue == "" {
+		t.Fatal("PATH is required for subprocess execution")
+	}
+
+	return []string{
+		"HOME=" + homeDir,
+		"XDG_CONFIG_HOME=" + configHome,
+		"PATH=" + pathValue,
+	}
+}
+
+func runOC(t *testing.T, env []string, args ...string) commandResult {
+	t.Helper()
+	binaryPath := os.Getenv("OC_E2E_BINARY")
+	if binaryPath == "" {
+		t.Skip("OC_E2E_BINARY not set; skipping black-box CLI E2E tests")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, binaryPath, args...)
+	cmd.Env = env
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+
+	return commandResult{
+		stdout: stdout.String(),
+		stderr: stderr.String(),
+		err:    err,
+	}
+}
+
+func requireSuccess(t *testing.T, result commandResult) {
+	t.Helper()
+	if result.err != nil {
+		t.Fatalf("expected success, got err=%v stdout=%q stderr=%q", result.err, result.stdout, result.stderr)
+	}
+}
+
+func requireFailure(t *testing.T, result commandResult) {
+	t.Helper()
+	if result.err == nil {
+		t.Fatalf("expected failure, got stdout=%q stderr=%q", result.stdout, result.stderr)
+	}
+}
+
+func requireContains(t *testing.T, haystack, needle string) {
+	t.Helper()
+	if !strings.Contains(haystack, needle) {
+		t.Fatalf("expected %q to contain %q", haystack, needle)
+	}
+}
+
+func extractSourceID(t *testing.T, stdout string) string {
+	t.Helper()
+	for _, line := range strings.Split(stdout, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "ID:") {
+			return strings.TrimSpace(strings.TrimPrefix(trimmed, "ID:"))
+		}
+	}
+	t.Fatalf("failed to extract source id from stdout=%q", stdout)
+	return ""
+}
+
+func readProvenance(t *testing.T, path string) provenance {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read provenance file: %v", err)
+	}
+
+	var prov provenance
+	if err := json.Unmarshal(data, &prov); err != nil {
+		t.Fatalf("failed to parse provenance file: %v", err)
+	}
+	return prov
+}
+
+func copyFixtureBundle(t *testing.T) string {
+	t.Helper()
+	sourceRoot := filepath.Join("testdata", "fixture-bundle")
+	destRoot := filepath.Join(t.TempDir(), "fixture-bundle")
+	copyDir(t, sourceRoot, destRoot)
+	return destRoot
+}
+
+func copyDir(t *testing.T, srcDir, destDir string) {
+	t.Helper()
+	entries, err := os.ReadDir(srcDir)
+	if err != nil {
+		t.Fatalf("failed to read fixture dir %s: %v", srcDir, err)
+	}
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		t.Fatalf("failed to create fixture dir %s: %v", destDir, err)
+	}
+
+	for _, entry := range entries {
+		srcPath := filepath.Join(srcDir, entry.Name())
+		destPath := filepath.Join(destDir, entry.Name())
+		if entry.IsDir() {
+			copyDir(t, srcPath, destPath)
+			continue
+		}
+
+		data, err := os.ReadFile(srcPath)
+		if err != nil {
+			t.Fatalf("failed to read fixture file %s: %v", srcPath, err)
+		}
+		if err := os.WriteFile(destPath, data, 0o644); err != nil {
+			t.Fatalf("failed to write fixture file %s: %v", destPath, err)
+		}
+	}
+}
+
+func createTarGzFromDir(t *testing.T, sourceDir, archivePath string) {
+	t.Helper()
+	archiveFile, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatalf("failed to create archive %s: %v", archivePath, err)
+	}
+	defer archiveFile.Close()
+
+	gzipWriter := gzip.NewWriter(archiveFile)
+	defer gzipWriter.Close()
+
+	tarWriter := tar.NewWriter(gzipWriter)
+	defer tarWriter.Close()
+
+	if err := filepath.Walk(sourceDir, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if info.IsDir() {
+			return nil
+		}
+
+		relPath, err := filepath.Rel(sourceDir, path)
+		if err != nil {
+			return err
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		header := &tar.Header{
+			Name: filepath.ToSlash(filepath.Join(filepath.Base(sourceDir), relPath)),
+			Mode: 0o644,
+			Size: int64(len(content)),
+		}
+		if err := tarWriter.WriteHeader(header); err != nil {
+			return err
+		}
+		if _, err := tarWriter.Write(content); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("failed to build tar.gz fixture: %v", err)
+	}
+	if err := tarWriter.Close(); err != nil {
+		t.Fatalf("failed to finalize tar writer: %v", err)
+	}
+	if err := gzipWriter.Close(); err != nil {
+		t.Fatalf("failed to finalize gzip writer: %v", err)
+	}
+	if err := archiveFile.Close(); err != nil {
+		t.Fatalf("failed to close archive file: %v", err)
+	}
+}

--- a/e2e/testdata/fixture-bundle/configs/fixture.json
+++ b/e2e/testdata/fixture-bundle/configs/fixture.json
@@ -1,0 +1,6 @@
+{
+  "default_agent": "docs",
+  "routing": {
+    "mode": "fixture"
+  }
+}

--- a/e2e/testdata/fixture-bundle/opencode-bundle.manifest.json
+++ b/e2e/testdata/fixture-bundle/opencode-bundle.manifest.json
@@ -1,0 +1,13 @@
+{
+  "manifest_version": "1.0.0",
+  "bundle_name": "fixture-bundle",
+  "bundle_version": "v1.0.0",
+  "bundle_root": ".",
+  "presets": [
+    {
+      "name": "fixture",
+      "entrypoint": "configs/fixture.json",
+      "description": "Fixture preset for black-box CLI tests"
+    }
+  ]
+}


### PR DESCRIPTION
Implements: US-052

## Summary
- add a dedicated `e2e-cli` GitHub Actions workflow that builds `oc` and runs black-box CLI tests on Linux and macOS
- add fixture-backed `e2e/` tests for local directory/archive flows plus key offline failure cases against the built binary
- document `US-052` traceability and maintain a durable CLI E2E coverage inventory for future additions

## Testing
- `OC_E2E_BINARY=\"$PWD/.tmp/oc\" go test ./e2e -v`
- `go test ./...`