### PR TITLE
US-052: update e2e docs after merged CI verification

### DIFF
--- a/docs/cli-e2e-coverage.md
+++ b/docs/cli-e2e-coverage.md
@@ -47,17 +47,17 @@ It is the durable inventory for what is already covered, what is verified in CI,
 
 | Scenario | Command(s) | Source Type | Status | CI Verified | Notes |
 |---|---|---|---|---|---|
-| Print version | `oc version` | n/a | Implemented | Yes | Verified by successful `main` workflow matrix run on Linux and macOS |
-| Register local directory source | `oc source add <dir>` | local directory | Implemented | Yes | Uses fixture bundle with manifest |
-| Register local archive source | `oc source add <tar.gz>` | local archive | Implemented | Yes | Archive generated at test runtime |
-| List registered sources | `oc source list` | registry | Implemented | Yes | Covered inside the local directory flow |
-| Apply preset from local directory source | `oc bundle apply <id> --preset <name>` | local directory | Implemented | Yes | Verifies written config and provenance |
-| Apply preset from local archive source | `oc bundle apply <id> --preset <name>` | local archive | Implemented | Yes | Exercises tar extraction path |
-| Show applied bundle provenance | `oc bundle status --project-root <dir>` | project provenance | Implemented | Yes | Reads `.opencode/bundle-provenance.json` through CLI |
-| Refuse overwrite without force | `oc bundle apply <id> --preset <name>` | local directory | Implemented | Yes | Must fail when output already exists |
-| Reject missing manifest source | `oc source add <dir>` | invalid local directory | Implemented | Yes | Validates manifest presence check |
-| Reject invalid tarball | `oc source add <tar.gz>` and/or `oc bundle apply <id> --preset <name>` | invalid local archive | Implemented | Yes | Verifies archive extraction failure path |
-| Reject unknown source ID | `oc bundle apply <id> --preset <name>` | registry lookup | Implemented | Yes | Verifies user-facing error path |
+| Print version | `oc version` | n/a | Implemented | ✅ | Verified by successful `main` workflow matrix run on Linux and macOS |
+| Register local directory source | `oc source add <dir>` | local directory | Implemented | ✅ | Uses fixture bundle with manifest |
+| Register local archive source | `oc source add <tar.gz>` | local archive | Implemented | ✅ | Archive generated at test runtime |
+| List registered sources | `oc source list` | registry | Implemented | ✅ | Covered inside the local directory flow |
+| Apply preset from local directory source | `oc bundle apply <id> --preset <name>` | local directory | Implemented | ✅ | Verifies written config and provenance |
+| Apply preset from local archive source | `oc bundle apply <id> --preset <name>` | local archive | Implemented | ✅ | Exercises tar extraction path |
+| Show applied bundle provenance | `oc bundle status --project-root <dir>` | project provenance | Implemented | ✅ | Reads `.opencode/bundle-provenance.json` through CLI |
+| Refuse overwrite without force | `oc bundle apply <id> --preset <name>` | local directory | Implemented | ✅ | Must fail when output already exists |
+| Reject missing manifest source | `oc source add <dir>` | invalid local directory | Implemented | ✅ | Validates manifest presence check |
+| Reject invalid tarball | `oc source add <tar.gz>` and/or `oc bundle apply <id> --preset <name>` | invalid local archive | Implemented | ✅ | Verifies archive extraction failure path |
+| Reject unknown source ID | `oc bundle apply <id> --preset <name>` | registry lookup | Implemented | ✅ | Verifies user-facing error path |
 
 ## Deferred Scenarios
 

--- a/docs/cli-e2e-coverage.md
+++ b/docs/cli-e2e-coverage.md
@@ -28,6 +28,10 @@ It is the durable inventory for what is already covered, what is verified in CI,
 - Current CI platforms:
   - `ubuntu-latest`
   - `macos-latest`
+- Latest verified `main` run:
+  - GitHub Actions run `23850747833`
+  - `E2E CLI (ubuntu-latest)`: success
+  - `E2E CLI (macos-latest)`: success
 
 ## Test Harness
 
@@ -43,17 +47,17 @@ It is the durable inventory for what is already covered, what is verified in CI,
 
 | Scenario | Command(s) | Source Type | Status | CI Verified | Notes |
 |---|---|---|---|---|---|
-| Print version | `oc version` | n/a | Implemented | No | Verifies built binary launches and prints version |
-| Register local directory source | `oc source add <dir>` | local directory | Implemented | No | Uses fixture bundle with manifest |
-| Register local archive source | `oc source add <tar.gz>` | local archive | Implemented | No | Archive generated at test runtime |
-| List registered sources | `oc source list` | registry | Implemented | No | Confirms isolated registry contents |
-| Apply preset from local directory source | `oc bundle apply <id> --preset <name>` | local directory | Implemented | No | Verifies written config and provenance |
-| Apply preset from local archive source | `oc bundle apply <id> --preset <name>` | local archive | Implemented | No | Exercises tar extraction path |
-| Show applied bundle provenance | `oc bundle status --project-root <dir>` | project provenance | Implemented | No | Reads `.opencode/bundle-provenance.json` through CLI |
-| Refuse overwrite without force | `oc bundle apply <id> --preset <name>` | local directory | Implemented | No | Must fail when output already exists |
-| Reject missing manifest source | `oc source add <dir>` | invalid local directory | Implemented | No | Validates manifest presence check |
-| Reject invalid tarball | `oc source add <tar.gz>` and/or `oc bundle apply <id> --preset <name>` | invalid local archive | Implemented | No | Verifies archive extraction failure path |
-| Reject unknown source ID | `oc bundle apply <id> --preset <name>` | registry lookup | Implemented | No | Verifies user-facing error path |
+| Print version | `oc version` | n/a | Implemented | Yes | Verified by successful `main` workflow matrix run on Linux and macOS |
+| Register local directory source | `oc source add <dir>` | local directory | Implemented | Yes | Uses fixture bundle with manifest |
+| Register local archive source | `oc source add <tar.gz>` | local archive | Implemented | Yes | Archive generated at test runtime |
+| List registered sources | `oc source list` | registry | Implemented | Yes | Covered inside the local directory flow |
+| Apply preset from local directory source | `oc bundle apply <id> --preset <name>` | local directory | Implemented | Yes | Verifies written config and provenance |
+| Apply preset from local archive source | `oc bundle apply <id> --preset <name>` | local archive | Implemented | Yes | Exercises tar extraction path |
+| Show applied bundle provenance | `oc bundle status --project-root <dir>` | project provenance | Implemented | Yes | Reads `.opencode/bundle-provenance.json` through CLI |
+| Refuse overwrite without force | `oc bundle apply <id> --preset <name>` | local directory | Implemented | Yes | Must fail when output already exists |
+| Reject missing manifest source | `oc source add <dir>` | invalid local directory | Implemented | Yes | Validates manifest presence check |
+| Reject invalid tarball | `oc source add <tar.gz>` and/or `oc bundle apply <id> --preset <name>` | invalid local archive | Implemented | Yes | Verifies archive extraction failure path |
+| Reject unknown source ID | `oc bundle apply <id> --preset <name>` | registry lookup | Implemented | Yes | Verifies user-facing error path |
 
 ## Deferred Scenarios
 
@@ -82,3 +86,4 @@ It is the durable inventory for what is already covered, what is verified in CI,
 
 - 2026-04-01: Document created for `US-052` initial local-flow coverage planning
 - 2026-04-01: Initial local-flow scenarios implemented in `e2e/` and wired into `.github/workflows/e2e-cli.yml`
+- 2026-04-01: Marked initial local-flow scenarios as CI-verified after successful `main` workflow run `23850747833` on Linux and macOS

--- a/docs/opencode-helper-cli.md
+++ b/docs/opencode-helper-cli.md
@@ -1451,7 +1451,10 @@ Priority:
 - P1
 
 Status:
-- Open
+- Done
+
+PR:
+- [#120](https://github.com/sven1103-agent/opencode-config-cli/pull/120)
 
 Type:
 - Release-engineering-facing

--- a/docs/opencode-helper-go-migration-milestones.md
+++ b/docs/opencode-helper-go-migration-milestones.md
@@ -20,9 +20,9 @@ The goal is to migrate from bash to Go for better JSON handling, testability, an
 
 | Status | Count | Legend |
 |--------|-------|--------|
-| ✅ Done | 8 | Completed and merged |
+| ✅ Done | 9 | Completed and merged |
 | ❌ Out of Scope | 1 | Not applicable to CLI |
-| ⏳ Open | 4 | Not yet started |
+| ⏳ Open | 3 | Not yet started |
 
 ---
 
@@ -141,7 +141,7 @@ Implementation:
 - `US-049`: ⏳ Open
 - `US-050`: ✅ Done (PR #90)
 - `US-051`: ⏳ Open
-- `US-052`: ⏳ Open
+- `US-052`: ✅ Done (PR #120)
 
 Why last:
 - These enhance the experience but are not required for core functionality
@@ -197,7 +197,7 @@ Shipped-binary coverage depends on core command stability:
 | 10 | `US-049` | ⏳ Open | Add --interactive flag |
 | 11 | `US-050` | ✅ Done | Set up goreleaser (PR #90) |
 | 12 | `US-051` | ⏳ Open | Create Homebrew tap |
-| 13 | `US-052` | ⏳ Open | Add CI-backed end-to-end coverage for the Go CLI |
+| 13 | `US-052` | ✅ Done | Add CI-backed end-to-end coverage for the Go CLI (PR #120) |
 
 ---
 


### PR DESCRIPTION
Implements: US-052

## Summary
- update the CLI E2E coverage inventory to mark the initial local-flow scenarios as CI-verified
- record the successful `main` workflow run and matrix verification for Linux and macOS
- close out `US-052` in the traceability and Go migration milestone docs with PR #120

## Testing
- `gh run list --workflow "E2E CLI" --limit 10`
- `gh run view 23850747833 --json jobs`