### PR TITLE
fix: validate goreleaser config before release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,3 +79,28 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: v1.61
+
+  goreleaser-dry-run:
+    name: GoReleaser Dry Run
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+          cache: true
+
+      - name: Validate GoReleaser config
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: '~> v2'
+          args: check
+
+      - name: Run GoReleaser snapshot build
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: '~> v2'
+          args: release --snapshot --clean --skip=publish

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,7 +11,7 @@ before:
     - go mod tidy
 
 builds:
-    - id: oc
+  - id: oc
     binary: oc
     main: ./main.go
     env:


### PR DESCRIPTION
## Summary
- fix the invalid `builds` indentation in `.goreleaser.yaml` so GoReleaser can parse the release config
- add a CI GoReleaser dry run that runs `goreleaser check` and a snapshot release build before changes land on `main`
- keep release verification aligned with the actual packaging path so release regressions fail in CI instead of during manual release runs

## Testing
- go test ./...
- goreleaser check
- goreleaser release --snapshot --clean --skip=publish