### PR TITLE
fix: stabilize go-install version e2e

### DIFF
--- a/e2e/go_install_test.go
+++ b/e2e/go_install_test.go
@@ -186,7 +186,14 @@ func createModuleZip(t *testing.T, repoRoot, zipPath, zipRoot, moduleVersion str
 			return err
 		}
 		if filepath.ToSlash(relPath) == "internal/version/version.go" {
-			data = []byte(strings.ReplaceAll(string(data), "var Version = \"0.0.0-dev\"", "var Version = \""+moduleVersion+"\""))
+			lines := strings.Split(string(data), "\n")
+			for i, line := range lines {
+				if strings.HasPrefix(line, "var Version = ") {
+					lines[i] = "var Version = \"" + moduleVersion + "\""
+					break
+				}
+			}
+			data = []byte(strings.Join(lines, "\n"))
 		}
 
 		info, err := entry.Info()


### PR DESCRIPTION
## Summary
- make the go-install E2E helper rewrite any `var Version = \"...\"` line in `internal/version/version.go`
- prevent the tagged install test from breaking when release bump PRs change the checked-in version before CI runs
- keep coverage for `go install module@version` reporting the requested tagged version

## Testing
- go test ./e2e -run TestGoInstallTaggedVersionReportsTag -v
- go test ./...