### PR TITLE
docs: clarify manual release download for issue #135

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -39,6 +39,8 @@ curl -L "https://github.com/sven1103-agent/opencode-config-cli/releases/download
 mv oc ~/.local/bin/
 ```
 
+Set `VERSION` on its own line before running `curl`. Do not collapse this into `VERSION=... curl ...`, because `${VERSION}` is expanded by the shell before that temporary assignment takes effect.
+
 **Available platforms:**
 - `darwin_amd64` — macOS Intel
 - `darwin_arm64` — macOS Apple Silicon


### PR DESCRIPTION
## Summary
- clarify that the manual download example must set \
  `VERSION` on its own line before `curl`
- explain that collapsing the example into `VERSION=... curl ...` causes shell expansion to build a malformed release URL
- document the reproduction behind issue #135 without changing CLI behavior

## Testing
- reproduced the reported failure pattern in `zsh` using the one-line form from issue #135
- confirmed the published `v1.0.0-alpha.4` release asset exists and the failure comes from shell expansion order