### PR TITLE
US-049: implement human-first source-aware apply flow

### DIFF
--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -1,9 +1,13 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/sven1103-agent/opencode-config-cli/internal/bundle"
@@ -15,11 +19,15 @@ var (
 	bundleProjectRoot    string
 	bundlePreset         string
 	bundleVersion        string
+	bundleAuto           bool
 	bundleForce          bool
 	bundleDryRun         bool
 	bundleOutput         string
 	bundleYes            bool
-	bundleResolveToLocal = bundle.ResolveToLocal
+	bundleResolveToLocal           = bundle.ResolveToLocal
+	bundlePromptIn       io.Reader = os.Stdin
+	bundlePromptOut      io.Writer = os.Stdout
+	bundleInputIsTTY               = isInteractiveTTY
 )
 
 // bundleCmd represents the bundle command
@@ -31,25 +39,27 @@ var bundleCmd = &cobra.Command{
 Apply, track, and update configuration bundles from registered sources.
 
 Examples:
-  oc bundle apply abc12345 --preset default
-  oc bundle status
-  oc bundle update abc12345`,
+	  oc bundle apply qbic --preset default
+	  oc bundle apply qbic
+	  oc bundle status
+	  oc bundle update abc12345`,
 }
 
 // bundleApplyCmd applies a preset from a registered config bundle
 var bundleApplyCmd = &cobra.Command{
-	Use:   "apply <source-id>",
+	Use:   "apply <source-ref>",
 	Short: "Apply a preset from a config bundle",
 	Long: `Apply a preset from a registered config bundle to a project.
 
-The source-id must reference a registered config source (see 'source list').
-The preset name must exist in the bundle's manifest.
+The source-ref may be either a registered source ID or a unique source name.
+In interactive terminals, omitting --preset opens a guided preset selection flow.
 
 Examples:
-  oc bundle apply abc12345 --preset default
-  oc bundle apply abc12345 --version v1.2.3 --preset default
-  oc bundle apply abc12345 --preset minimal --project-root ./myproject
-  oc bundle apply abc12345 --preset default --force`,
+	  oc bundle apply qbic --preset default
+	  oc bundle apply qbic
+	  oc bundle apply abc12345 --version v1.2.3 --preset default
+	  oc bundle apply qbic --preset minimal --project-root ./myproject
+	  oc bundle apply qbic --auto --preset default --force`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runBundleApply(args[0])
@@ -98,13 +108,16 @@ func init() {
 	bundleCmd.AddCommand(bundleUpdateCmd)
 
 	// Flags for bundle apply
-	bundleApplyCmd.Flags().StringVar(&bundlePreset, "preset", "", "Preset name to apply (required)")
+	bundleApplyCmd.Flags().StringVar(&bundlePreset, "preset", "", "Preset name to apply")
 	bundleApplyCmd.Flags().StringVar(&bundleVersion, "version", "", "Bundle version/tag to apply for github-release sources")
 	bundleApplyCmd.Flags().StringVar(&bundleProjectRoot, "project-root", ".", "Project root directory")
 	bundleApplyCmd.Flags().StringVar(&bundleOutput, "output", "opencode.json", "Output file path")
+	bundleApplyCmd.Flags().BoolVar(&bundleAuto, "auto", false, "Disable interactive preset selection")
 	bundleApplyCmd.Flags().BoolVar(&bundleForce, "force", false, "Overwrite existing files")
 	bundleApplyCmd.Flags().BoolVar(&bundleDryRun, "dry-run", false, "Show what would be done without doing it")
-	_ = bundleApplyCmd.MarkFlagRequired("preset") //nolint:errcheck
+	bundleApplyCmd.ValidArgsFunction = completeSourceRefs
+	_ = bundleApplyCmd.RegisterFlagCompletionFunc("preset", completeBundlePresetNames)
+	bundleUpdateCmd.ValidArgsFunction = completeSourceRefs
 
 	// Flags for bundle status
 	bundleStatusCmd.Flags().StringVar(&bundleProjectRoot, "project-root", ".", "Project root directory")
@@ -113,12 +126,7 @@ func init() {
 	bundleUpdateCmd.Flags().BoolVar(&bundleYes, "yes", false, "Skip confirmation prompt")
 }
 
-func runBundleApply(sourceID string) error {
-	// Validate preset name is provided
-	if bundlePreset == "" {
-		return fmt.Errorf("--preset is required")
-	}
-
+func runBundleApply(sourceRef string) error {
 	// Resolve project root
 	projectRoot, err := filepath.Abs(bundleProjectRoot)
 	if err != nil {
@@ -130,10 +138,10 @@ func runBundleApply(sourceID string) error {
 		return fmt.Errorf("project root does not exist: %s", projectRoot)
 	}
 
-	// Get the source from registry
-	src, err := source.GetSource(sourceID)
+	// Resolve the source from registry
+	src, err := source.ResolveSourceRef(sourceRef)
 	if err != nil {
-		return fmt.Errorf("source not found: %s", sourceID)
+		return err
 	}
 	if bundleVersion != "" && string(src.Type) != "github-release" {
 		return fmt.Errorf("--version is only supported for github-release sources")
@@ -153,10 +161,21 @@ func runBundleApply(sourceID string) error {
 		return fmt.Errorf("failed to load manifest: %w", err)
 	}
 
+	selectedPreset := bundlePreset
+	if selectedPreset == "" {
+		if bundleAuto || !bundleInputIsTTY() {
+			return fmt.Errorf("--preset is required outside interactive mode")
+		}
+		selectedPreset, err = promptForPresetSelection(manifest)
+		if err != nil {
+			return err
+		}
+	}
+
 	// Get preset from manifest
-	bundlePresetEntry, err := bundle.GetPreset(manifest, bundlePreset)
+	bundlePresetEntry, err := bundle.GetPreset(manifest, selectedPreset)
 	if err != nil {
-		return fmt.Errorf("preset not found in bundle: %s", bundlePreset)
+		return fmt.Errorf("preset not found in bundle: %s", selectedPreset)
 	}
 
 	// Resolve output path
@@ -176,7 +195,7 @@ func runBundleApply(sourceID string) error {
 
 	// Dry run mode
 	if bundleDryRun {
-		fmt.Printf("dry-run: apply preset '%s' from bundle '%s'\n", bundlePreset, manifest.BundleName)
+		fmt.Printf("dry-run: apply preset '%s' from bundle '%s'\n", selectedPreset, manifest.BundleName)
 		fmt.Printf("dry-run: write config to %s\n", outputPath)
 		return nil
 	}
@@ -189,11 +208,11 @@ func runBundleApply(sourceID string) error {
 
 	// Write provenance
 	prov := &bundle.Provenance{
-		SourceID:      sourceID,
+		SourceID:      src.ID,
 		SourceName:    src.Name,
 		SourceType:    string(src.Type),
 		BundleVersion: manifest.BundleVersion,
-		PresetName:    bundlePreset,
+		PresetName:    selectedPreset,
 		Entrypoint:    bundlePresetEntry.Entrypoint,
 		AppliedAt:     "2026-03-31T00:00:00Z", // Would use time.Now().Format(time.RFC3339)
 	}
@@ -205,6 +224,123 @@ func runBundleApply(sourceID string) error {
 	fmt.Println("done: bundle applied")
 
 	return nil
+}
+
+func promptForPresetSelection(manifest *bundle.Manifest) (string, error) {
+	if len(manifest.Presets) == 0 {
+		return "", fmt.Errorf("bundle has no presets to select")
+	}
+
+	reader := bufio.NewReader(bundlePromptIn)
+	for {
+		fmt.Fprintf(bundlePromptOut, "Available presets for %s:\n", manifest.BundleName)
+		for i, preset := range manifest.Presets {
+			if preset.Description != "" {
+				fmt.Fprintf(bundlePromptOut, "  %d) %s - %s\n", i+1, preset.Name, preset.Description)
+				continue
+			}
+			fmt.Fprintf(bundlePromptOut, "  %d) %s\n", i+1, preset.Name)
+		}
+		fmt.Fprint(bundlePromptOut, "Select a preset: ")
+
+		selection, err := reader.ReadString('\n')
+		if err != nil {
+			if err == io.EOF {
+				return "", fmt.Errorf("interactive preset selection cancelled")
+			}
+			return "", fmt.Errorf("failed to read preset selection: %w", err)
+		}
+
+		selection = strings.TrimSpace(selection)
+		if index, err := strconv.Atoi(selection); err == nil {
+			if index >= 1 && index <= len(manifest.Presets) {
+				return manifest.Presets[index-1].Name, nil
+			}
+		} else {
+			for _, preset := range manifest.Presets {
+				if preset.Name == selection {
+					return preset.Name, nil
+				}
+			}
+		}
+
+		fmt.Fprintln(bundlePromptOut, "Invalid selection. Please enter a preset number or exact name.")
+	}
+}
+
+func isInteractiveTTY() bool {
+	info, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return info.Mode()&os.ModeCharDevice != 0
+}
+
+func completeSourceRefs(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	sources, err := source.ListSources()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	seen := map[string]struct{}{}
+	var refs []string
+	for _, src := range sources {
+		for _, candidate := range sourceCompletionCandidates(src) {
+			if !strings.HasPrefix(candidate, toComplete) {
+				continue
+			}
+			if _, ok := seen[candidate]; ok {
+				continue
+			}
+			seen[candidate] = struct{}{}
+			refs = append(refs, candidate)
+		}
+	}
+
+	return refs, cobra.ShellCompDirectiveNoFileComp
+}
+
+func completeBundlePresetNames(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) == 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	src, err := source.ResolveSourceRef(args[0])
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	versionTag := ""
+	if flag := cmd.Flags().Lookup("version"); flag != nil {
+		versionTag = flag.Value.String()
+	}
+
+	bundleRoot, cleanup, err := bundleResolveToLocal(string(src.Type), src.Location, versionTag)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	defer cleanup()
+
+	manifest, err := bundle.LoadManifest(filepath.Join(bundleRoot, "opencode-bundle.manifest.json"))
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	var presets []string
+	for _, preset := range manifest.Presets {
+		if strings.HasPrefix(preset.Name, toComplete) {
+			presets = append(presets, preset.Name)
+		}
+	}
+
+	return presets, cobra.ShellCompDirectiveNoFileComp
+}
+
+func sourceCompletionCandidates(src source.Source) []string {
+	if src.Name == "" || src.Name == src.ID {
+		return []string{src.ID}
+	}
+	return []string{src.ID, src.Name}
 }
 
 func runBundleStatus() error {
@@ -232,11 +368,11 @@ func runBundleStatus() error {
 	return nil
 }
 
-func runBundleUpdate(sourceID string) error {
+func runBundleUpdate(sourceRef string) error {
 	// Get the source from registry
-	src, err := source.GetSource(sourceID)
+	src, err := source.ResolveSourceRef(sourceRef)
 	if err != nil {
-		return fmt.Errorf("source not found: %s", sourceID)
+		return err
 	}
 
 	// For now, github-release is required for updates (as per shell script behavior)

--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -252,15 +252,15 @@ func promptForPresetSelection(manifest *bundle.Manifest) (string, error) {
 		}
 
 		selection = strings.TrimSpace(selection)
+		for _, preset := range manifest.Presets {
+			if preset.Name == selection {
+				return preset.Name, nil
+			}
+		}
+
 		if index, err := strconv.Atoi(selection); err == nil {
 			if index >= 1 && index <= len(manifest.Presets) {
 				return manifest.Presets[index-1].Name, nil
-			}
-		} else {
-			for _, preset := range manifest.Presets {
-				if preset.Name == selection {
-					return preset.Name, nil
-				}
 			}
 		}
 

--- a/cmd/bundle_test.go
+++ b/cmd/bundle_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -42,6 +43,7 @@ func TestBundleApplyNoSource(t *testing.T) {
 		bundleForce = origForce
 		bundleDryRun = origDryRun
 		bundleOutput = origOutput
+		bundleAuto = false
 	}()
 
 	// Test with nonexistent source
@@ -57,14 +59,46 @@ func TestBundleApplyNoSource(t *testing.T) {
 
 // TestBundleApplyMissingPreset tests applying with missing preset flag
 func TestBundleApplyMissingPreset(t *testing.T) {
+	restore := saveRegistry(t)
+	defer restore()
+
+	bundleDir := t.TempDir()
+	manifest := `{"manifest_version":"1.0.0","bundle_name":"local","bundle_version":"v1.0.0","presets":[{"name":"test","entrypoint":"test.json","description":"Test preset"}]}`
+	if err := os.WriteFile(filepath.Join(bundleDir, "opencode-bundle.manifest.json"), []byte(manifest), 0644); err != nil {
+		t.Fatalf("failed to write manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(bundleDir, "test.json"), []byte(`{"agents":[]}`), 0644); err != nil {
+		t.Fatalf("failed to write preset: %v", err)
+	}
+
+	registry, _ := source.LoadRegistry()
+	registry.Sources = []source.Source{{ID: "abc12345", Name: "qbic", Type: source.SourceTypeLocalDirectory, Location: bundleDir}}
+	if err := source.SaveRegistry(registry); err != nil {
+		t.Fatalf("failed to save registry: %v", err)
+	}
+
 	origPreset := bundlePreset
+	origAuto := bundleAuto
+	origTTY := bundleInputIsTTY
+	origProjectRoot := bundleProjectRoot
 	defer func() { bundlePreset = origPreset }()
+	defer func() {
+		bundleAuto = origAuto
+		bundleInputIsTTY = origTTY
+		bundleProjectRoot = origProjectRoot
+	}()
 
 	bundlePreset = ""
+	bundleAuto = false
+	bundleInputIsTTY = func() bool { return false }
+	bundleProjectRoot = t.TempDir()
 
 	err := runBundleApply("abc12345")
 	if err == nil {
 		t.Error("runBundleApply() expected error when preset is missing")
+	}
+	if !strings.Contains(err.Error(), "--preset is required outside interactive mode") {
+		t.Fatalf("runBundleApply() error = %v", err)
 	}
 }
 
@@ -196,6 +230,9 @@ func TestBundleApplyFlags(t *testing.T) {
 	if bundleApplyCmd.Flags().Lookup("preset") == nil {
 		t.Error("preset flag should exist on bundle apply command")
 	}
+	if bundleApplyCmd.Flags().Lookup("auto") == nil {
+		t.Error("auto flag should exist on bundle apply command")
+	}
 	if bundleApplyCmd.Flags().Lookup("project-root") == nil {
 		t.Error("project-root flag should exist on bundle apply command")
 	}
@@ -273,5 +310,155 @@ func TestBundleApplyRejectsVersionForLocalSources(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "--version is only supported for github-release sources") {
 		t.Fatalf("runBundleApply() error = %v", err)
+	}
+}
+
+func TestBundleApplyResolvesSourceByName(t *testing.T) {
+	restore := saveRegistry(t)
+	defer restore()
+
+	bundleDir := t.TempDir()
+	manifest := `{"manifest_version":"1.0.0","bundle_name":"local","bundle_version":"v1.0.0","presets":[{"name":"test","entrypoint":"test.json","description":"Test preset"}]}`
+	if err := os.WriteFile(filepath.Join(bundleDir, "opencode-bundle.manifest.json"), []byte(manifest), 0644); err != nil {
+		t.Fatalf("failed to write manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(bundleDir, "test.json"), []byte(`{"agents":[]}`), 0644); err != nil {
+		t.Fatalf("failed to write preset: %v", err)
+	}
+
+	registry, _ := source.LoadRegistry()
+	registry.Sources = []source.Source{{
+		ID:       "local1",
+		Location: bundleDir,
+		Type:     source.SourceTypeLocalDirectory,
+		Name:     "qbic",
+	}}
+	if err := source.SaveRegistry(registry); err != nil {
+		t.Fatalf("failed to save registry: %v", err)
+	}
+
+	projectRoot := setupTestProject(t)
+	defer os.RemoveAll(projectRoot)
+
+	origPreset := bundlePreset
+	origProjectRoot := bundleProjectRoot
+	defer func() {
+		bundlePreset = origPreset
+		bundleProjectRoot = origProjectRoot
+	}()
+
+	bundlePreset = "test"
+	bundleProjectRoot = projectRoot
+
+	if err := runBundleApply("qbic"); err != nil {
+		t.Fatalf("runBundleApply() error = %v", err)
+	}
+
+	prov, err := bundle.LoadProvenance(projectRoot)
+	if err != nil {
+		t.Fatalf("LoadProvenance() error = %v", err)
+	}
+	if prov.SourceID != "local1" {
+		t.Fatalf("provenance SourceID = %q, want local1", prov.SourceID)
+	}
+}
+
+func TestBundleApplyRejectsAmbiguousSourceName(t *testing.T) {
+	restore := saveRegistry(t)
+	defer restore()
+
+	registry, _ := source.LoadRegistry()
+	registry.Sources = []source.Source{{ID: "id-1", Name: "qbic", Type: source.SourceTypeLocalDirectory, Location: "/tmp/a"}, {ID: "id-2", Name: "qbic", Type: source.SourceTypeLocalDirectory, Location: "/tmp/b"}}
+	if err := source.SaveRegistry(registry); err != nil {
+		t.Fatalf("failed to save registry: %v", err)
+	}
+
+	origPreset := bundlePreset
+	bundlePreset = "test"
+	defer func() { bundlePreset = origPreset }()
+
+	err := runBundleApply("qbic")
+	if err == nil {
+		t.Fatal("runBundleApply() error = nil, want ambiguous source error")
+	}
+	if !strings.Contains(err.Error(), "ambiguous") || !strings.Contains(err.Error(), "id-1") || !strings.Contains(err.Error(), "id-2") {
+		t.Fatalf("runBundleApply() error = %v", err)
+	}
+}
+
+func TestBundleApplyInteractiveSelectsPreset(t *testing.T) {
+	restore := saveRegistry(t)
+	defer restore()
+
+	bundleDir := t.TempDir()
+	manifest := `{"manifest_version":"1.0.0","bundle_name":"local","bundle_version":"v1.0.0","presets":[{"name":"first","entrypoint":"first.json","description":"First preset"},{"name":"second","entrypoint":"second.json","description":"Second preset"}]}`
+	if err := os.WriteFile(filepath.Join(bundleDir, "opencode-bundle.manifest.json"), []byte(manifest), 0644); err != nil {
+		t.Fatalf("failed to write manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(bundleDir, "first.json"), []byte(`{"name":"first"}`), 0644); err != nil {
+		t.Fatalf("failed to write first preset: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(bundleDir, "second.json"), []byte(`{"name":"second"}`), 0644); err != nil {
+		t.Fatalf("failed to write second preset: %v", err)
+	}
+
+	registry, _ := source.LoadRegistry()
+	registry.Sources = []source.Source{{ID: "local1", Name: "qbic", Type: source.SourceTypeLocalDirectory, Location: bundleDir}}
+	if err := source.SaveRegistry(registry); err != nil {
+		t.Fatalf("failed to save registry: %v", err)
+	}
+
+	projectRoot := setupTestProject(t)
+	defer os.RemoveAll(projectRoot)
+
+	origPreset := bundlePreset
+	origAuto := bundleAuto
+	origTTY := bundleInputIsTTY
+	origPromptIn := bundlePromptIn
+	origPromptOut := bundlePromptOut
+	defer func() {
+		bundlePreset = origPreset
+		bundleAuto = origAuto
+		bundleInputIsTTY = origTTY
+		bundlePromptIn = origPromptIn
+		bundlePromptOut = origPromptOut
+	}()
+
+	bundlePreset = ""
+	bundleAuto = false
+	bundleProjectRoot = projectRoot
+	bundleInputIsTTY = func() bool { return true }
+	bundlePromptIn = strings.NewReader("2\n")
+	bundlePromptOut = io.Discard
+
+	if err := runBundleApply("qbic"); err != nil {
+		t.Fatalf("runBundleApply() error = %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(projectRoot, "opencode.json"))
+	if err != nil {
+		t.Fatalf("failed to read written config: %v", err)
+	}
+	if string(content) != `{"name":"second"}` {
+		t.Fatalf("written config = %s", content)
+	}
+}
+
+func TestCompleteSourceRefs(t *testing.T) {
+	restore := saveRegistry(t)
+	defer restore()
+
+	registry, _ := source.LoadRegistry()
+	registry.Sources = []source.Source{{ID: "id-1", Name: "qbic", Type: source.SourceTypeLocalDirectory, Location: "/tmp/a"}}
+	if err := source.SaveRegistry(registry); err != nil {
+		t.Fatalf("failed to save registry: %v", err)
+	}
+
+	completions, directive := completeSourceRefs(nil, nil, "q")
+	if directive != 4 { // cobra.ShellCompDirectiveNoFileComp
+		t.Fatalf("directive = %v", directive)
+	}
+	if len(completions) != 1 || completions[0] != "qbic" {
+		t.Fatalf("completions = %v", completions)
 	}
 }

--- a/cmd/bundle_test.go
+++ b/cmd/bundle_test.go
@@ -444,6 +444,34 @@ func TestBundleApplyInteractiveSelectsPreset(t *testing.T) {
 	}
 }
 
+func TestBundleApplyInteractiveAcceptsNumericLikePresetName(t *testing.T) {
+	manifest := &bundle.Manifest{
+		BundleName: "numeric-fixture",
+		Presets: []bundle.Preset{
+			{Name: "first", Description: "First preset"},
+			{Name: "2", Description: "Numeric-like preset"},
+		},
+	}
+
+	origPromptIn := bundlePromptIn
+	origPromptOut := bundlePromptOut
+	defer func() {
+		bundlePromptIn = origPromptIn
+		bundlePromptOut = origPromptOut
+	}()
+
+	bundlePromptIn = strings.NewReader("2\n")
+	bundlePromptOut = io.Discard
+
+	selected, err := promptForPresetSelection(manifest)
+	if err != nil {
+		t.Fatalf("promptForPresetSelection() error = %v", err)
+	}
+	if selected != "2" {
+		t.Fatalf("selected preset = %q, want %q", selected, "2")
+	}
+}
+
 func TestCompleteSourceRefs(t *testing.T) {
 	restore := saveRegistry(t)
 	defer restore()

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var completionCmd = &cobra.Command{
+	Use:       "completion [bash|zsh|fish|powershell]",
+	Short:     "Generate shell completions",
+	Long:      "Generate shell completion scripts for supported shells.",
+	Args:      cobra.ExactArgs(1),
+	ValidArgs: []string{"bash", "zsh", "fish", "powershell"},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		switch args[0] {
+		case "bash":
+			return rootCmd.GenBashCompletion(os.Stdout)
+		case "zsh":
+			return rootCmd.GenZshCompletion(os.Stdout)
+		case "fish":
+			return rootCmd.GenFishCompletion(os.Stdout, true)
+		case "powershell":
+			return rootCmd.GenPowerShellCompletionWithDesc(os.Stdout)
+		default:
+			return fmt.Errorf("unsupported shell: %s", args[0])
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(completionCmd)
+}

--- a/cmd/preset.go
+++ b/cmd/preset.go
@@ -4,16 +4,21 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"text/tabwriter"
 
 	"github.com/spf13/cobra"
+	"github.com/sven1103-agent/opencode-config-cli/internal/bundle"
 	"github.com/sven1103-agent/opencode-config-cli/internal/preset"
+	"github.com/sven1103-agent/opencode-config-cli/internal/source"
 )
 
 var (
-	presetProjectRoot string
-	presetOutput      string
-	presetForce       bool
-	presetDryRun      bool
+	presetProjectRoot    string
+	presetOutput         string
+	presetForce          bool
+	presetDryRun         bool
+	presetSources        bool
+	presetResolveToLocal = bundle.ResolveToLocal
 )
 
 // presetCmd represents the preset command
@@ -22,19 +27,14 @@ var presetCmd = &cobra.Command{
 	Short: "Manage OpenCode presets",
 	Long: `Manage OpenCode configuration presets.
 
-Available presets:
-  - mixed: Mixed model configuration (default)
-  - openai: OpenAI-focused configuration
-  - big-pickle: Big-pickle configuration
-  - minimax: Minimax configuration
-  - kimi: Kimi configuration`,
+Use 'preset list' for built-in presets or 'preset list --sources' to browse registered sources.`,
 }
 
 // presetListCmd lists all available presets
 var presetListCmd = &cobra.Command{
 	Use:   "list",
-	Short: "List all available presets",
-	Long:  "List all available presets that can be used with 'preset use'",
+	Short: "List available presets",
+	Long:  "List built-in presets or browse presets across registered sources with --sources",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runPresetList()
 	},
@@ -73,14 +73,67 @@ func init() {
 	presetUseCmd.Flags().StringVar(&presetOutput, "output", "opencode.json", "Output file path")
 	presetUseCmd.Flags().BoolVar(&presetForce, "force", false, "Overwrite existing files")
 	presetUseCmd.Flags().BoolVar(&presetDryRun, "dry-run", false, "Show what would be done without doing it")
+	presetListCmd.Flags().BoolVar(&presetSources, "sources", false, "List presets across registered sources")
 }
 
 func runPresetList() error {
+	if presetSources {
+		return runSourcePresetList()
+	}
+
 	presets := preset.ValidPresets()
 	fmt.Println("Available presets:")
 	for _, p := range presets {
 		fmt.Printf("  - %s\n", p)
 	}
+	return nil
+}
+
+func runSourcePresetList() error {
+	sources, err := source.ListSources()
+	if err != nil {
+		return fmt.Errorf("failed to list sources: %w", err)
+	}
+	if len(sources) == 0 {
+		return fmt.Errorf("no sources registered. Use 'oc source add <location>' first")
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(w, "SOURCE_REF\tSOURCE_ID\tBUNDLE_VERSION\tPRESET\tDESCRIPTION\n")
+	fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", "──────────", "─────────", "──────────────", "──────", "───────────")
+
+	foundPreset := false
+	for _, src := range sources {
+		bundleRoot, cleanup, err := presetResolveToLocal(string(src.Type), src.Location, "")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to inspect source %s (%s): %v\n", src.Name, src.ID, err)
+			continue
+		}
+
+		manifest, err := bundle.LoadManifest(filepath.Join(bundleRoot, "opencode-bundle.manifest.json"))
+		cleanup()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to inspect source %s (%s): %v\n", src.Name, src.ID, err)
+			continue
+		}
+
+		ref := src.ID
+		if src.Name != "" {
+			ref = src.Name
+		}
+		for _, preset := range manifest.Presets {
+			foundPreset = true
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", ref, src.ID, manifest.BundleVersion, preset.Name, preset.Description)
+		}
+	}
+
+	if err := w.Flush(); err != nil {
+		return fmt.Errorf("failed to write output: %w", err)
+	}
+	if !foundPreset {
+		return fmt.Errorf("no inspectable source presets found")
+	}
+
 	return nil
 }
 

--- a/cmd/preset_test.go
+++ b/cmd/preset_test.go
@@ -1,8 +1,13 @@
 package cmd
 
 import (
+	"io"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/sven1103-agent/opencode-config-cli/internal/source"
 )
 
 func TestRunPresetList(t *testing.T) {
@@ -64,5 +69,66 @@ func TestPresetListCmdFlags(t *testing.T) {
 	cmd := presetListCmd
 	if cmd.Flags().Lookup("project-root") != nil {
 		t.Error("preset list should not have project-root flag")
+	}
+	if cmd.Flags().Lookup("sources") == nil {
+		t.Error("preset list should have sources flag")
+	}
+}
+
+func TestRunPresetListSources(t *testing.T) {
+	restore := saveRegistry(t)
+	defer restore()
+
+	bundleDir := t.TempDir()
+	manifest := `{"manifest_version":"1.0.0","bundle_name":"qbic","bundle_version":"v1.2.3","presets":[{"name":"mixed","entrypoint":"mixed.json","description":"Mixed preset"}]}`
+	if err := os.WriteFile(filepath.Join(bundleDir, "opencode-bundle.manifest.json"), []byte(manifest), 0644); err != nil {
+		t.Fatalf("failed to write manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(bundleDir, "mixed.json"), []byte(`{"agents":[]}`), 0644); err != nil {
+		t.Fatalf("failed to write preset: %v", err)
+	}
+
+	registry, _ := source.LoadRegistry()
+	registry.Sources = []source.Source{{ID: "id-1", Name: "qbic", Type: source.SourceTypeLocalDirectory, Location: bundleDir}}
+	if err := source.SaveRegistry(registry); err != nil {
+		t.Fatalf("failed to save registry: %v", err)
+	}
+
+	origSources := presetSources
+	origStdout := os.Stdout
+	origStderr := os.Stderr
+	defer func() {
+		presetSources = origSources
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+	}()
+
+	rOut, wOut, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create stdout pipe: %v", err)
+	}
+	rErr, wErr, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create stderr pipe: %v", err)
+	}
+	os.Stdout = wOut
+	os.Stderr = wErr
+	presetSources = true
+
+	err = runPresetList()
+	wOut.Close()
+	wErr.Close()
+	if err != nil {
+		t.Fatalf("runPresetList() error = %v", err)
+	}
+
+	stdoutBytes, _ := io.ReadAll(rOut)
+	stderrBytes, _ := io.ReadAll(rErr)
+	if len(stderrBytes) != 0 {
+		t.Fatalf("stderr = %s", stderrBytes)
+	}
+	stdout := string(stdoutBytes)
+	if !strings.Contains(stdout, "qbic") || !strings.Contains(stdout, "v1.2.3") || !strings.Contains(stdout, "mixed") {
+		t.Fatalf("stdout = %s", stdout)
 	}
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,9 @@ oc source add qbicsoftware/opencode-config-bundle --name qbic
 
 # Apply a preset
 oc bundle apply qbic --preset mixed --project-root .
+
+# Or let the CLI prompt for a preset in a TTY
+oc bundle apply qbic --project-root .
 ```
 
 ## Available Bundles

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -62,17 +62,19 @@ Apply and manage config bundles.
 Apply a preset from a registered source.
 
 ```sh
-oc bundle apply <source-id> --preset <preset> --project-root <path>
+oc bundle apply <source-ref> [--preset <preset>] [--auto] --project-root <path>
 ```
 
 **Options:**
-- `--preset` — Preset name to apply (required)
+- `--preset` — Preset name to apply
+- `--auto` — Disable interactive preset selection in TTY mode
 - `--project-root` — Target directory (default: `.`)
 
 **Example:**
 
 ```sh
 oc bundle apply qbic --preset mixed --project-root ./myproject
+oc bundle apply qbic --project-root ./myproject
 ```
 
 ### oc bundle status
@@ -107,7 +109,17 @@ List available presets.
 oc preset list --sources
 ```
 
-Shows presets from all registered sources.
+Shows presets from all registered sources with source and bundle context.
+
+### oc completion
+
+Generate shell completions.
+
+```sh
+oc completion bash
+oc completion zsh
+oc completion fish
+```
 
 ## Migration Commands
 

--- a/docs/config-bundles.md
+++ b/docs/config-bundles.md
@@ -38,6 +38,7 @@ oc preset list --sources
 
 ```sh
 oc bundle apply qbic --preset mixed --project-root .
+oc bundle apply qbic --project-root .
 ```
 
 ## Creating Your Own Bundle

--- a/docs/specs/opencode-helper-cli.md
+++ b/docs/specs/opencode-helper-cli.md
@@ -1385,10 +1385,11 @@ Priority:
 - P3
 
 Status:
-- In progress
+- In review
 
 PR:
 - [#141](https://github.com/sven1103-agent/opencode-config-cli/pull/141)
+- TBD
 
 Type:
 - User-facing

--- a/docs/specs/opencode-helper-cli.md
+++ b/docs/specs/opencode-helper-cli.md
@@ -1389,7 +1389,7 @@ Status:
 
 PR:
 - [#141](https://github.com/sven1103-agent/opencode-config-cli/pull/141)
-- TBD
+- [#142](https://github.com/sven1103-agent/opencode-config-cli/pull/142)
 
 Type:
 - User-facing

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -102,6 +102,26 @@ func TestLocalDirectoryFlow(t *testing.T) {
 	}
 }
 
+func TestLocalDirectoryApplyBySourceName(t *testing.T) {
+	env := testEnv(t)
+	bundleDir := copyFixtureBundle(t)
+	projectRoot := t.TempDir()
+
+	addResult := runOC(t, env, "source", "add", bundleDir, "--name", "fixture-dir")
+	requireSuccess(t, addResult)
+
+	applyResult := runOC(t, env, "bundle", "apply", "fixture-dir", "--preset", "fixture", "--project-root", projectRoot)
+	requireSuccess(t, applyResult)
+
+	prov := readProvenance(t, filepath.Join(projectRoot, ".opencode", "bundle-provenance.json"))
+	if prov.SourceName != "fixture-dir" {
+		t.Fatalf("expected source name fixture-dir, got %q", prov.SourceName)
+	}
+	if prov.PresetName != "fixture" {
+		t.Fatalf("expected preset fixture, got %q", prov.PresetName)
+	}
+}
+
 func TestLocalArchiveFlow(t *testing.T) {
 	env := testEnv(t)
 	bundleDir := copyFixtureBundle(t)
@@ -198,6 +218,19 @@ func TestBundleApplyFailsForUnknownSource(t *testing.T) {
 	result := runOC(t, testEnv(t), "bundle", "apply", "missing-id", "--preset", "fixture", "--project-root", projectRoot)
 	requireFailure(t, result)
 	requireContains(t, result.stderr, "source not found")
+}
+
+func TestBundleApplyRequiresPresetOutsideTTY(t *testing.T) {
+	env := testEnv(t)
+	bundleDir := copyFixtureBundle(t)
+	projectRoot := t.TempDir()
+
+	addResult := runOC(t, env, "source", "add", bundleDir, "--name", "fixture-dir")
+	requireSuccess(t, addResult)
+
+	applyResult := runOC(t, env, "bundle", "apply", "fixture-dir", "--project-root", projectRoot)
+	requireFailure(t, applyResult)
+	requireContains(t, applyResult.stderr, "--preset is required outside interactive mode")
 }
 
 func TestSourceAddFailsWithoutManifest(t *testing.T) {

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -228,7 +228,7 @@ func TestBundleApplyRequiresPresetOutsideTTY(t *testing.T) {
 	addResult := runOC(t, env, "source", "add", bundleDir, "--name", "fixture-dir")
 	requireSuccess(t, addResult)
 
-	applyResult := runOC(t, env, "bundle", "apply", "fixture-dir", "--project-root", projectRoot)
+	applyResult := runOCWithStdin(t, env, strings.NewReader(""), "bundle", "apply", "fixture-dir", "--project-root", projectRoot)
 	requireFailure(t, applyResult)
 	requireContains(t, applyResult.stderr, "--preset is required outside interactive mode")
 }
@@ -284,6 +284,11 @@ func testEnv(t *testing.T) []string {
 
 func runOC(t *testing.T, env []string, args ...string) commandResult {
 	t.Helper()
+	return runOCWithStdin(t, env, nil, args...)
+}
+
+func runOCWithStdin(t *testing.T, env []string, stdin *strings.Reader, args ...string) commandResult {
+	t.Helper()
 	binaryPath := os.Getenv("OC_E2E_BINARY")
 	if binaryPath == "" {
 		t.Skip("OC_E2E_BINARY not set; skipping black-box CLI E2E tests")
@@ -294,6 +299,9 @@ func runOC(t *testing.T, env []string, args ...string) commandResult {
 
 	cmd := exec.CommandContext(ctx, binaryPath, args...)
 	cmd.Env = env
+	if stdin != nil {
+		cmd.Stdin = stdin
+	}
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -45,6 +46,20 @@ type Registry struct {
 type GitHubRef struct {
 	Repo string
 	Tag  string
+}
+
+// AmbiguousSourceRefError reports when a source name matches more than one source.
+type AmbiguousSourceRefError struct {
+	Ref     string
+	Matches []Source
+}
+
+func (e *AmbiguousSourceRefError) Error() string {
+	parts := make([]string, 0, len(e.Matches))
+	for _, match := range e.Matches {
+		parts = append(parts, fmt.Sprintf("%s (%s)", match.Name, match.ID))
+	}
+	return fmt.Sprintf("source name is ambiguous: %s (matches: %s)", e.Ref, strings.Join(parts, ", "))
 }
 
 var ownerRepoPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`)
@@ -349,4 +364,42 @@ func GetSource(id string) (*Source, error) {
 	}
 
 	return nil, fmt.Errorf("source not found: %s", id)
+}
+
+// ResolveSourceRef resolves a source reference by exact ID or unique name.
+func ResolveSourceRef(ref string) (*Source, error) {
+	registry, err := LoadRegistry()
+	if err != nil {
+		return nil, err
+	}
+
+	trimmed := strings.TrimSpace(ref)
+	if trimmed == "" {
+		return nil, fmt.Errorf("source reference cannot be empty")
+	}
+
+	for _, s := range registry.Sources {
+		if s.ID == trimmed {
+			return &s, nil
+		}
+	}
+
+	var matches []Source
+	for _, s := range registry.Sources {
+		if s.Name == trimmed {
+			matches = append(matches, s)
+		}
+	}
+
+	switch len(matches) {
+	case 0:
+		return nil, fmt.Errorf("source not found: %s", ref)
+	case 1:
+		return &matches[0], nil
+	default:
+		sort.Slice(matches, func(i, j int) bool {
+			return matches[i].ID < matches[j].ID
+		})
+		return nil, &AmbiguousSourceRefError{Ref: trimmed, Matches: matches}
+	}
 }

--- a/internal/source/source_test.go
+++ b/internal/source/source_test.go
@@ -1,7 +1,10 @@
 package source
 
 import (
+	"encoding/json"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -119,6 +122,68 @@ func TestValidateSource_GitHubInput(t *testing.T) {
 	err := ValidateSource("qbicsoftware/opencode-config-bundle", SourceTypeGitHubRelease)
 	if err != nil {
 		t.Fatalf("ValidateSource() error = %v", err)
+	}
+}
+
+func TestResolveSourceRef(t *testing.T) {
+	setRegistryForTest(t, []Source{
+		{ID: "id-1", Name: "qbic", Type: SourceTypeLocalDirectory, Location: "/tmp/a"},
+		{ID: "id-2", Name: "other", Type: SourceTypeLocalDirectory, Location: "/tmp/b"},
+	})
+
+	byID, err := ResolveSourceRef("id-1")
+	if err != nil {
+		t.Fatalf("ResolveSourceRef(id) error = %v", err)
+	}
+	if byID.Name != "qbic" {
+		t.Fatalf("ResolveSourceRef(id).Name = %q", byID.Name)
+	}
+
+	byName, err := ResolveSourceRef("qbic")
+	if err != nil {
+		t.Fatalf("ResolveSourceRef(name) error = %v", err)
+	}
+	if byName.ID != "id-1" {
+		t.Fatalf("ResolveSourceRef(name).ID = %q", byName.ID)
+	}
+}
+
+func TestResolveSourceRefAmbiguousName(t *testing.T) {
+	setRegistryForTest(t, []Source{
+		{ID: "id-1", Name: "qbic", Type: SourceTypeLocalDirectory, Location: "/tmp/a"},
+		{ID: "id-2", Name: "qbic", Type: SourceTypeLocalDirectory, Location: "/tmp/b"},
+	})
+
+	_, err := ResolveSourceRef("qbic")
+	if err == nil {
+		t.Fatal("ResolveSourceRef() error = nil, want ambiguity error")
+	}
+	if !strings.Contains(err.Error(), "ambiguous") || !strings.Contains(err.Error(), "id-1") || !strings.Contains(err.Error(), "id-2") {
+		t.Fatalf("ResolveSourceRef() error = %v", err)
+	}
+}
+
+func setRegistryForTest(t *testing.T, sources []Source) {
+	t.Helper()
+	configDir := t.TempDir()
+	homeDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configDir)
+	t.Setenv("HOME", homeDir)
+
+	registryPath, err := RegistryPath()
+	if err != nil {
+		t.Fatalf("failed to resolve registry path: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(registryPath), 0755); err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+
+	data, err := json.Marshal(&Registry{Version: 1, Sources: sources})
+	if err != nil {
+		t.Fatalf("failed to marshal registry: %v", err)
+	}
+	if err := os.WriteFile(registryPath, data, 0644); err != nil {
+		t.Fatalf("failed to write registry: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- resolve source refs by either source ID or unique source name and surface clear ambiguity errors
- make `oc bundle apply` human-first in TTY mode with guided preset selection, while keeping `--auto` and non-TTY usage deterministic
- add `oc preset list --sources`, shell completion generation, and command-specific completions for source refs and preset names

## Verification
- `go test ./...`

Implements: US-049
Also advances: US-027, US-028, US-048