### PR TITLE
fix: generate categorized PR-based release notes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,7 @@ This PR implements a user story from `docs/opencode-helper-cli.md`.
 Required:
 - Title starts with `US-###: ...` (primary story only)
 - Body includes an `Implements: US-###` line (primary story)
+- Apply exactly one release-note type label (recommended: `kind:feature`, `kind:fix`, `kind:chore`, or `kind:docs`)
 
 ## Story
 
@@ -25,9 +26,14 @@ PRD: docs/opencode-helper-cli.md#us-###
 
 - ...
 
+## Release Notes
+
+- Release note summary: ...
+
 ## Reviewer Checklist
 
 - [ ] PR title uses primary `US-###:` and body includes `Implements: US-###`
+- [ ] PR has exactly one release-note type label (`kind:*` preferred)
 - [ ] If `Also advances:` is present, those IDs are not marked `Done` unless fully completed
 - [ ] `docs/opencode-helper-cli.md` primary story entry is updated with `PR: <link/#>`
 - [ ] `docs/opencode-helper-cli.md` primary story `Status` is `Done` only when all acceptance criteria are satisfied

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,28 @@
+changelog:
+  exclude:
+    labels:
+      - skip-release-notes
+  categories:
+    - title: Breaking Changes
+      labels:
+        - kind:breaking
+    - title: Features
+      labels:
+        - kind:feature
+        - enhancement
+    - title: Bug Fixes
+      labels:
+        - kind:fix
+        - bug
+    - title: Maintenance
+      labels:
+        - kind:chore
+    - title: Documentation
+      labels:
+        - kind:docs
+        - documentation
+change-template: '- $TITLE in #$NUMBER by @$AUTHOR'
+template: |
+  ## What's Changed
+
+  $CHANGES

--- a/.github/workflows/release-go-binary.yml
+++ b/.github/workflows/release-go-binary.yml
@@ -79,3 +79,18 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate categorized GitHub release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            /repos/${{ github.repository }}/releases/generate-notes \
+            -f tag_name='${{ steps.version.outputs.tag }}' \
+            --jq '.body' > release-notes.md
+
+          gh release edit '${{ steps.version.outputs.tag }}' \
+            --notes-file release-notes.md

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,12 +31,7 @@ builds:
       - -X github.com/sven1103-agent/opencode-config-cli/internal/version.Version={{.Version}}
 
 changelog:
-  sort: desc
-  filters:
-    exclude:
-      - "^docs:"
-      - "^test:"
-      - "^chore:"
+  disable: true
 
 release:
   github:


### PR DESCRIPTION
## Summary
- switch published release notes from GoReleaser's raw commit changelog to GitHub-generated notes after the release is created
- add `.github/release.yml` so release notes are grouped by PR labels and include PR references automatically
- update the PR template and create `kind:*` labels so contributors can classify release-note entries consistently

## Testing
- `goreleaser check`
- `gh api --method POST -H \"Accept: application/vnd.github+json\" /repos/sven1103-agent/opencode-config-cli/releases/generate-notes -f tag_name='v1.0.0-alpha.4' --jq '.body'`