### PR TITLE
docs: clarify GitHub bundle release contract

### DIFF
--- a/docs/config-bundles.md
+++ b/docs/config-bundles.md
@@ -37,9 +37,15 @@ oc preset list --sources
 ### 3. Apply a Preset
 
 ```sh
+oc bundle apply qbic --version v1.0.0 --preset mixed --project-root .
 oc bundle apply qbic --preset mixed --project-root .
-oc bundle apply qbic --project-root .
 ```
+
+If a source publishes multiple versions, the CLI should support:
+
+- explicit version selection with `--version <tag>`
+- `latest` for the latest stable release
+- interactive version selection in a TTY, ordered newest first and clearly labeling prereleases
 
 ## Creating Your Own Bundle
 
@@ -83,11 +89,15 @@ Create `opencode-bundle.manifest.json` at your bundle root:
 
 ### 4. Publish as GitHub Release
 
-1. Create a GitHub release
-2. Attach a `.tar.gz` archive containing:
-   - `opencode-bundle.manifest.json` at root
-   - All preset files
-3. (Optional) Add a `-checksums.txt` for integrity verification
+1. Create a GitHub release. Stable releases and prereleases are both valid bundle sources.
+2. Attach a `.tar.gz` bundle archive containing:
+   - `opencode-bundle.manifest.json` at root, or under a single top-level directory
+   - All preset files referenced by the manifest
+   - `.opencode/schemas/` when your bundle ships the canonical session schemas
+3. Attach a matching `-checksums.txt` file using SHA-256.
+4. Do not rely on GitHub's auto-generated source tarballs as the primary consumable bundle artifact.
+
+See `docs/specs/bundle-contract.md` for the full GitHub-release distribution contract and a copy-pasteable GitHub Actions example workflow.
 
 ### 5. Register Your Bundle
 

--- a/docs/specs/bundle-contract.md
+++ b/docs/specs/bundle-contract.md
@@ -133,6 +133,133 @@ The CLI rejects a bundle when:
 
 ---
 
+## GitHub Release Distribution
+
+This section defines how a bundle must be published when it is distributed as a GitHub-release source for the `oc` CLI.
+
+### Supported Release Types
+
+- Stable releases are valid bundle sources.
+- Prereleases are also valid bundle sources and are recommended for smoke testing.
+- A bundle repository may publish only prereleases, only stable releases, or both.
+
+The CLI should not treat a prerelease-only repository as invalid by default.
+
+### Version Selection Semantics
+
+For GitHub-release sources, the CLI is expected to support these selection modes:
+
+- explicit version tag selection via `--version <tag>`
+- `latest` selection for the latest stable release
+- interactive version selection when multiple usable versions exist and the command is running in a TTY
+
+Interactive selection should list versions newest first and clearly label prereleases.
+
+If a repository has no stable releases but does have prereleases, the CLI should surface that clearly instead of returning a generic GitHub API `404` error.
+
+### Required Release Assets
+
+For a GitHub-release bundle source, the release must publish these assets:
+
+- a bundle archive, typically `opencode-config-bundle-<tag>.tar.gz`
+- a checksum file for the published bundle archive, typically `opencode-config-bundle-<tag>-checksums.txt`
+
+The bundle archive must unpack into a normalized bundle root that contains exactly one `opencode-bundle.manifest.json` and all files referenced by that manifest.
+
+The checksum file must:
+
+- use SHA-256
+- contain an entry for the published bundle archive
+- match the uploaded archive byte-for-byte
+
+### Archive Layout
+
+The uploaded archive must contain either:
+
+- the bundle files directly at the archive root, or
+- a single top-level directory that contains the bundle root
+
+In both cases, after extraction the CLI must be able to resolve a normalized bundle root containing:
+
+```text
+<bundle-root>/
+  opencode-bundle.manifest.json
+  <preset-entrypoint>.json
+  .opencode/schemas/
+    handoff.schema.json
+    result.schema.json
+```
+
+### GitHub Auto-Generated Source Archives
+
+GitHub's auto-generated source archives (`tarball_url` / `zipball_url`) should not be relied on as the primary distribution contract for bundle consumers.
+
+Reasons:
+
+- their naming is not bundle-contract-specific
+- they do not provide contract-specific checksum metadata by default
+- they make the intended consumable artifact less obvious to maintainers and users
+
+For predictable distribution and verification, maintainers should publish an explicit bundle archive asset and matching checksum asset with each release.
+
+---
+
+## Example GitHub Actions Release Workflow
+
+This example shows a minimal release workflow for a bundle repository. It stages the bundle contents, creates the release archive, generates a SHA-256 checksum file, and uploads both assets to the GitHub release.
+
+```yaml
+name: Release Bundle
+
+on:
+  push:
+    tags:
+      - "v*"
+      - "*-alpha.*"
+      - "*-beta.*"
+      - "*-rc.*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Stage bundle contents
+        run: |
+          set -eu
+          mkdir -p dist/bundle/.opencode/schemas
+          cp opencode-bundle.manifest.json dist/bundle/
+          cp opencode.*.json dist/bundle/
+          cp .opencode/schemas/handoff.schema.json dist/bundle/.opencode/schemas/
+          cp .opencode/schemas/result.schema.json dist/bundle/.opencode/schemas/
+
+      - name: Create bundle archive
+        run: |
+          set -eu
+          tar -czf "opencode-config-bundle-${GITHUB_REF_NAME}.tar.gz" -C dist bundle
+
+      - name: Generate SHA-256 checksums
+        run: |
+          set -eu
+          shasum -a 256 "opencode-config-bundle-${GITHUB_REF_NAME}.tar.gz" > "opencode-config-bundle-${GITHUB_REF_NAME}-checksums.txt"
+
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            opencode-config-bundle-${{ github.ref_name }}.tar.gz
+            opencode-config-bundle-${{ github.ref_name }}-checksums.txt
+```
+
+Maintainers may generate the manifest file ahead of time or as part of the release workflow, but the uploaded archive must always satisfy the bundle-root contract above.
+
+---
+
 ## Future Extensions
 
 ### US-EXT-001 - Support Custom Tools in Bundles

--- a/docs/specs/opencode-helper-cli.md
+++ b/docs/specs/opencode-helper-cli.md
@@ -704,7 +704,15 @@ At minimum, the capability model shall distinguish whether a source supports:
 - version selection
 - update checks
 
+For GitHub-release sources, capability handling shall also distinguish whether:
+
+- stable releases are available
+- prereleases are available
+- integrity metadata is available for the selected release
+
 Commands that depend on a capability shall surface a clear error when invoked against a source that does not support it.
+
+When a GitHub-release source has multiple usable versions and the user did not pass `--version`, the CLI should prefer an interactive version-selection prompt in TTY contexts and otherwise return a clear error that explains how to select a version explicitly.
 
 Depends on:
 - [REQ-F-021](#req-f-021)
@@ -718,6 +726,8 @@ Verification requirements:
 - the remote source shall expose integrity metadata sufficient for the CLI to verify the downloaded bundle
 - bundle apply or update shall fail closed if integrity metadata is missing, unreadable, or does not match the downloaded bundle
 - no downloaded remote bundle contents shall be activated for use if integrity verification fails
+
+For GitHub-release sources, the expected integrity metadata is a release-published checksum asset that covers the bundle archive selected for apply or update.
 
 Depends on:
 - [REQ-F-024](#req-f-024)
@@ -2675,11 +2685,15 @@ Story:
 Acceptance criteria:
 - Given a GitHub release source pointing at a valid bundle asset, when I register it, then the CLI records it as a GitHub-release source and can discover presets from its manifest.
 - Given that registered GitHub-release source, when I run `opencode-helper bundle apply <source-id> --version <tag> --preset <name> --project-root <path>`, then the CLI downloads or reuses the selected release asset, resolves it to a normalized bundle root, validates the manifest, and applies the preset.
+- Given that registered GitHub-release source publishes prereleases, when I explicitly select a prerelease tag, then the CLI treats it as a valid bundle version for smoke testing.
+- Given that registered GitHub-release source has multiple usable versions and I do not pass `--version`, when the command runs in a TTY, then the CLI prompts me to choose a version starting with the newest release first and clearly labels prereleases.
 
 Notes:
 - The CLI accepts GitHub release sources as bare `owner/repo`, `github.com/owner/repo`, or a `https://github.com/<owner>/<repo>/releases/tag/<tag>` URL.
 - A valid GitHub release source must publish at least one bundle `.tar.gz` asset whose extracted contents contain `opencode-bundle.manifest.json` either at archive root or under a single top-level directory.
-- If the release also publishes a matching `-checksums.txt` asset, the CLI verifies the downloaded bundle before apply and fails closed on checksum mismatch.
+- A valid GitHub release source may publish stable releases, prereleases, or both.
+- The default `latest` selector refers to the latest stable release.
+- If the release publishes a matching `-checksums.txt` asset, the CLI verifies the downloaded bundle before apply and fails closed on checksum mismatch.
 
 ---
 
@@ -2772,6 +2786,7 @@ Acceptance criteria:
 - Given a registered source, when I run `opencode-helper source list`, then the CLI shows which relevant capabilities that source supports.
 - Given I invoke a capability-dependent command against a source that does not support it, when the command runs, then the CLI exits non-zero with a clear capability error.
 - Given a local directory or local `.tar.gz` source, when the CLI inspects it, then update-check capability is not reported unless explicitly supported by that source type in a future iteration.
+- Given a GitHub-release source with prereleases but no stable releases, when I inspect or apply that source without `--version`, then the CLI reports that only prereleases are available and guides me toward explicit selection or interactive choice instead of surfacing a generic GitHub API `404`.
 
 ---
 


### PR DESCRIPTION
## Summary
- clarify that GitHub bundle sources may publish stable releases, prereleases, or both
- define expected GitHub release assets, checksum metadata, and archive layout for bundle distribution
- add a copy-pasteable GitHub Actions workflow example and align the traceable PRD with prerelease/version-selection behavior

## Issues
- related: qbicsoftware/opencode-config-bundle#3

## Traceability
- Primary story: US-035
- Related: US-038, US-039