### PR TITLE
fix: support prerelease bundle version selection

### DIFF
--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -146,7 +146,7 @@ func runBundleApply(sourceRef string) error {
 	}
 	selectedVersion := bundleVersion
 	if string(src.Type) == "github-release" {
-		selectedVersion, err = resolveGitHubBundleVersion(src.Location, bundleVersion)
+		selectedVersion, err = resolveGitHubBundleVersion(src.Location, bundleVersion, true)
 		if err != nil {
 			return err
 		}
@@ -234,7 +234,7 @@ func runBundleApply(sourceRef string) error {
 	return nil
 }
 
-func resolveGitHubBundleVersion(sourceLocation, requestedVersion string) (string, error) {
+func resolveGitHubBundleVersion(sourceLocation, requestedVersion string, allowPrompt bool) (string, error) {
 	if requestedVersion != "" {
 		return requestedVersion, nil
 	}
@@ -251,19 +251,44 @@ func resolveGitHubBundleVersion(sourceLocation, requestedVersion string) (string
 	if err != nil {
 		return "", err
 	}
-
-	if len(releases) == 1 {
-		return releases[0].TagName, nil
-	}
-
-	if bundleAuto || !bundleInputIsTTY() {
+	if !allowPrompt || bundleAuto || !bundleInputIsTTY() {
 		if hasStableGitHubRelease(releases) {
 			return "", fmt.Errorf("--version is required for github-release sources outside interactive mode (use --version latest or --version <tag>)")
 		}
 		return "", fmt.Errorf("--version is required for github-release sources outside interactive mode; only prereleases are available (use --version <tag>)")
 	}
 
+	if len(releases) == 1 {
+		return releases[0].TagName, nil
+	}
+
 	return promptForGitHubReleaseSelection(sourceLocation, releases)
+}
+
+func inspectGitHubBundleVersion(sourceLocation, requestedVersion string) (string, error) {
+	if requestedVersion != "" {
+		return requestedVersion, nil
+	}
+
+	ref, err := source.ParseGitHubLocation(sourceLocation)
+	if err != nil {
+		return "", err
+	}
+	if ref.Tag != "" {
+		return ref.Tag, nil
+	}
+
+	releases, err := bundleListGitHubReleases(sourceLocation)
+	if err != nil {
+		return "", err
+	}
+	for _, release := range releases {
+		if !release.Prerelease {
+			return release.TagName, nil
+		}
+	}
+
+	return "", fmt.Errorf("no stable release found for %s; prereleases are available", ref.Repo)
 }
 
 func promptForPresetSelection(manifest *bundle.Manifest) (string, error) {
@@ -406,7 +431,7 @@ func completeBundlePresetNames(cmd *cobra.Command, args []string, toComplete str
 		versionTag = flag.Value.String()
 	}
 	if string(src.Type) == "github-release" {
-		versionTag, err = resolveGitHubBundleVersion(src.Location, versionTag)
+		versionTag, err = inspectGitHubBundleVersion(src.Location, versionTag)
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}

--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -16,18 +16,19 @@ import (
 )
 
 var (
-	bundleProjectRoot    string
-	bundlePreset         string
-	bundleVersion        string
-	bundleAuto           bool
-	bundleForce          bool
-	bundleDryRun         bool
-	bundleOutput         string
-	bundleYes            bool
-	bundleResolveToLocal           = bundle.ResolveToLocal
-	bundlePromptIn       io.Reader = os.Stdin
-	bundlePromptOut      io.Writer = os.Stdout
-	bundleInputIsTTY               = isInteractiveTTY
+	bundleProjectRoot        string
+	bundlePreset             string
+	bundleVersion            string
+	bundleAuto               bool
+	bundleForce              bool
+	bundleDryRun             bool
+	bundleOutput             string
+	bundleYes                bool
+	bundleResolveToLocal               = bundle.ResolveToLocal
+	bundleListGitHubReleases           = bundle.ListGitHubReleases
+	bundlePromptIn           io.Reader = os.Stdin
+	bundlePromptOut          io.Writer = os.Stdout
+	bundleInputIsTTY                   = isInteractiveTTY
 )
 
 // bundleCmd represents the bundle command
@@ -143,12 +144,19 @@ func runBundleApply(sourceRef string) error {
 	if err != nil {
 		return err
 	}
+	selectedVersion := bundleVersion
+	if string(src.Type) == "github-release" {
+		selectedVersion, err = resolveGitHubBundleVersion(src.Location, bundleVersion)
+		if err != nil {
+			return err
+		}
+	}
 	if bundleVersion != "" && string(src.Type) != "github-release" {
 		return fmt.Errorf("--version is only supported for github-release sources")
 	}
 
 	// Resolve source to local bundle root
-	bundleRoot, cleanup, err := bundleResolveToLocal(string(src.Type), src.Location, bundleVersion)
+	bundleRoot, cleanup, err := bundleResolveToLocal(string(src.Type), src.Location, selectedVersion)
 	if err != nil {
 		return fmt.Errorf("failed to resolve source: %w", err)
 	}
@@ -226,6 +234,38 @@ func runBundleApply(sourceRef string) error {
 	return nil
 }
 
+func resolveGitHubBundleVersion(sourceLocation, requestedVersion string) (string, error) {
+	if requestedVersion != "" {
+		return requestedVersion, nil
+	}
+
+	ref, err := source.ParseGitHubLocation(sourceLocation)
+	if err != nil {
+		return "", err
+	}
+	if ref.Tag != "" {
+		return ref.Tag, nil
+	}
+
+	releases, err := bundleListGitHubReleases(sourceLocation)
+	if err != nil {
+		return "", err
+	}
+
+	if len(releases) == 1 {
+		return releases[0].TagName, nil
+	}
+
+	if bundleAuto || !bundleInputIsTTY() {
+		if hasStableGitHubRelease(releases) {
+			return "", fmt.Errorf("--version is required for github-release sources outside interactive mode (use --version latest or --version <tag>)")
+		}
+		return "", fmt.Errorf("--version is required for github-release sources outside interactive mode; only prereleases are available (use --version <tag>)")
+	}
+
+	return promptForGitHubReleaseSelection(sourceLocation, releases)
+}
+
 func promptForPresetSelection(manifest *bundle.Manifest) (string, error) {
 	if len(manifest.Presets) == 0 {
 		return "", fmt.Errorf("bundle has no presets to select")
@@ -266,6 +306,57 @@ func promptForPresetSelection(manifest *bundle.Manifest) (string, error) {
 
 		fmt.Fprintln(bundlePromptOut, "Invalid selection. Please enter a preset number or exact name.")
 	}
+}
+
+func promptForGitHubReleaseSelection(sourceLocation string, releases []bundle.GitHubReleaseVersion) (string, error) {
+	if len(releases) == 0 {
+		return "", fmt.Errorf("github-release source has no versions to select")
+	}
+
+	reader := bufio.NewReader(bundlePromptIn)
+	for {
+		fmt.Fprintf(bundlePromptOut, "Available versions for %s:\n", sourceLocation)
+		for i, release := range releases {
+			label := release.TagName
+			if release.Prerelease {
+				label += " (prerelease)"
+			}
+			fmt.Fprintf(bundlePromptOut, "  %d) %s\n", i+1, label)
+		}
+		fmt.Fprint(bundlePromptOut, "Select a version: ")
+
+		selection, err := reader.ReadString('\n')
+		if err != nil {
+			if err == io.EOF {
+				return "", fmt.Errorf("interactive version selection cancelled")
+			}
+			return "", fmt.Errorf("failed to read version selection: %w", err)
+		}
+
+		selection = strings.TrimSpace(selection)
+		for _, release := range releases {
+			if release.TagName == selection {
+				return release.TagName, nil
+			}
+		}
+
+		if index, err := strconv.Atoi(selection); err == nil {
+			if index >= 1 && index <= len(releases) {
+				return releases[index-1].TagName, nil
+			}
+		}
+
+		fmt.Fprintln(bundlePromptOut, "Invalid selection. Please enter a version number or exact tag.")
+	}
+}
+
+func hasStableGitHubRelease(releases []bundle.GitHubReleaseVersion) bool {
+	for _, release := range releases {
+		if !release.Prerelease {
+			return true
+		}
+	}
+	return false
 }
 
 func isInteractiveTTY() bool {
@@ -313,6 +404,12 @@ func completeBundlePresetNames(cmd *cobra.Command, args []string, toComplete str
 	versionTag := ""
 	if flag := cmd.Flags().Lookup("version"); flag != nil {
 		versionTag = flag.Value.String()
+	}
+	if string(src.Type) == "github-release" {
+		versionTag, err = resolveGitHubBundleVersion(src.Location, versionTag)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
 	}
 
 	bundleRoot, cleanup, err := bundleResolveToLocal(string(src.Type), src.Location, versionTag)

--- a/cmd/bundle_test.go
+++ b/cmd/bundle_test.go
@@ -1,12 +1,14 @@
 package cmd
 
 import (
+	"bytes"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/sven1103-agent/opencode-config-cli/internal/bundle"
 	"github.com/sven1103-agent/opencode-config-cli/internal/source"
 )
@@ -375,6 +377,104 @@ func TestBundleApplyGitHubSourceReportsPrereleaseOnlyOutsideInteractiveMode(t *t
 	}
 	if !strings.Contains(err.Error(), "only prereleases are available") {
 		t.Fatalf("runBundleApply() error = %v", err)
+	}
+}
+
+func TestBundleApplyGitHubSourceSinglePrereleaseStillRequiresVersionOutsideInteractiveMode(t *testing.T) {
+	restore := saveRegistry(t)
+	defer restore()
+
+	registry, _ := source.LoadRegistry()
+	registry.Sources = []source.Source{{
+		ID:       "github1",
+		Location: "qbicsoftware/opencode-config-bundle",
+		Type:     source.SourceTypeGitHubRelease,
+		Name:     "qbic",
+	}}
+	if err := source.SaveRegistry(registry); err != nil {
+		t.Fatalf("failed to save registry: %v", err)
+	}
+
+	origPreset := bundlePreset
+	origVersion := bundleVersion
+	origListReleases := bundleListGitHubReleases
+	origTTY := bundleInputIsTTY
+	defer func() {
+		bundlePreset = origPreset
+		bundleVersion = origVersion
+		bundleListGitHubReleases = origListReleases
+		bundleInputIsTTY = origTTY
+	}()
+
+	bundlePreset = "test"
+	bundleVersion = ""
+	bundleInputIsTTY = func() bool { return false }
+	bundleListGitHubReleases = func(string) ([]bundle.GitHubReleaseVersion, error) {
+		return []bundle.GitHubReleaseVersion{{TagName: "v1.4.0-alpha.1", Prerelease: true}}, nil
+	}
+
+	err := runBundleApply("github1")
+	if err == nil {
+		t.Fatal("runBundleApply() error = nil, want prerelease-only version-selection error")
+	}
+	if !strings.Contains(err.Error(), "only prereleases are available") {
+		t.Fatalf("runBundleApply() error = %v", err)
+	}
+}
+
+func TestCompleteBundlePresetNamesGitHubSourceUsesNonInteractiveInspection(t *testing.T) {
+	restore := saveRegistry(t)
+	defer restore()
+
+	registry, _ := source.LoadRegistry()
+	registry.Sources = []source.Source{{ID: "github1", Name: "qbic", Type: source.SourceTypeGitHubRelease, Location: "qbicsoftware/opencode-config-bundle"}}
+	if err := source.SaveRegistry(registry); err != nil {
+		t.Fatalf("failed to save registry: %v", err)
+	}
+
+	origResolver := bundleResolveToLocal
+	origListReleases := bundleListGitHubReleases
+	origTTY := bundleInputIsTTY
+	origPromptOut := bundlePromptOut
+	defer func() {
+		bundleResolveToLocal = origResolver
+		bundleListGitHubReleases = origListReleases
+		bundleInputIsTTY = origTTY
+		bundlePromptOut = origPromptOut
+	}()
+
+	bundleInputIsTTY = func() bool { return true }
+	var promptOutput bytes.Buffer
+	bundlePromptOut = &promptOutput
+	bundleListGitHubReleases = func(string) ([]bundle.GitHubReleaseVersion, error) {
+		return []bundle.GitHubReleaseVersion{{TagName: "v2.0.0-alpha.1", Prerelease: true}, {TagName: "v1.9.0", Prerelease: false}}, nil
+	}
+	bundleResolveToLocal = func(sourceType, sourceLocation, versionTag string) (string, func(), error) {
+		if versionTag != "v1.9.0" {
+			t.Fatalf("versionTag = %q, want latest stable", versionTag)
+		}
+		bundleRoot := t.TempDir()
+		manifest := `{"manifest_version":"1.0.0","bundle_name":"qbic","bundle_version":"v1.9.0","presets":[{"name":"test","entrypoint":"test.json"}]}`
+		if err := os.WriteFile(filepath.Join(bundleRoot, "opencode-bundle.manifest.json"), []byte(manifest), 0644); err != nil {
+			return "", nil, err
+		}
+		if err := os.WriteFile(filepath.Join(bundleRoot, "test.json"), []byte(`{"agents":[]}`), 0644); err != nil {
+			return "", nil, err
+		}
+		return bundleRoot, func() {}, nil
+	}
+
+	cmd := &cobra.Command{}
+	cmd.Flags().String("version", "", "")
+	completions, directive := completeBundlePresetNames(cmd, []string{"qbic"}, "t")
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Fatalf("directive = %v", directive)
+	}
+	if promptOutput.Len() != 0 {
+		t.Fatalf("completion should not prompt, got %q", promptOutput.String())
+	}
+	if len(completions) != 1 || completions[0] != "test" {
+		t.Fatalf("completions = %v", completions)
 	}
 }
 

--- a/cmd/bundle_test.go
+++ b/cmd/bundle_test.go
@@ -225,6 +225,159 @@ func TestBundleApplyPassesVersionForGitHubSources(t *testing.T) {
 	}
 }
 
+func TestBundleApplyInteractiveSelectsGitHubReleaseVersion(t *testing.T) {
+	restore := saveRegistry(t)
+	defer restore()
+
+	registry, _ := source.LoadRegistry()
+	registry.Sources = []source.Source{{
+		ID:       "github1",
+		Location: "qbicsoftware/opencode-config-bundle",
+		Type:     source.SourceTypeGitHubRelease,
+		Name:     "qbic",
+	}}
+	if err := source.SaveRegistry(registry); err != nil {
+		t.Fatalf("failed to save registry: %v", err)
+	}
+
+	projectRoot := setupTestProject(t)
+	defer os.RemoveAll(projectRoot)
+
+	origPreset := bundlePreset
+	origProjectRoot := bundleProjectRoot
+	origVersion := bundleVersion
+	origResolver := bundleResolveToLocal
+	origListReleases := bundleListGitHubReleases
+	origTTY := bundleInputIsTTY
+	origPromptIn := bundlePromptIn
+	origPromptOut := bundlePromptOut
+	defer func() {
+		bundlePreset = origPreset
+		bundleProjectRoot = origProjectRoot
+		bundleVersion = origVersion
+		bundleResolveToLocal = origResolver
+		bundleListGitHubReleases = origListReleases
+		bundleInputIsTTY = origTTY
+		bundlePromptIn = origPromptIn
+		bundlePromptOut = origPromptOut
+	}()
+
+	bundlePreset = "test"
+	bundleProjectRoot = projectRoot
+	bundleVersion = ""
+	bundleInputIsTTY = func() bool { return true }
+	bundlePromptIn = strings.NewReader("2\n")
+	bundlePromptOut = io.Discard
+	bundleListGitHubReleases = func(location string) ([]bundle.GitHubReleaseVersion, error) {
+		if location != "qbicsoftware/opencode-config-bundle" {
+			t.Fatalf("location = %q", location)
+		}
+		return []bundle.GitHubReleaseVersion{{TagName: "v1.3.0", Prerelease: false}, {TagName: "v1.4.0-alpha.1", Prerelease: true}}, nil
+	}
+	bundleResolveToLocal = func(sourceType, sourceLocation, versionTag string) (string, func(), error) {
+		if versionTag != "v1.4.0-alpha.1" {
+			t.Fatalf("versionTag = %q, want prerelease selection", versionTag)
+		}
+		bundleRoot := t.TempDir()
+		manifest := `{"manifest_version":"1.0.0","bundle_name":"qbic","bundle_version":"v1.4.0-alpha.1","presets":[{"name":"test","entrypoint":"test.json"}]}`
+		if err := os.WriteFile(filepath.Join(bundleRoot, "opencode-bundle.manifest.json"), []byte(manifest), 0644); err != nil {
+			return "", nil, err
+		}
+		if err := os.WriteFile(filepath.Join(bundleRoot, "test.json"), []byte(`{"agents":[]}`), 0644); err != nil {
+			return "", nil, err
+		}
+		return bundleRoot, func() {}, nil
+	}
+
+	if err := runBundleApply("github1"); err != nil {
+		t.Fatalf("runBundleApply() error = %v", err)
+	}
+}
+
+func TestBundleApplyGitHubSourceRequiresVersionOutsideInteractiveMode(t *testing.T) {
+	restore := saveRegistry(t)
+	defer restore()
+
+	registry, _ := source.LoadRegistry()
+	registry.Sources = []source.Source{{
+		ID:       "github1",
+		Location: "qbicsoftware/opencode-config-bundle",
+		Type:     source.SourceTypeGitHubRelease,
+		Name:     "qbic",
+	}}
+	if err := source.SaveRegistry(registry); err != nil {
+		t.Fatalf("failed to save registry: %v", err)
+	}
+
+	origPreset := bundlePreset
+	origVersion := bundleVersion
+	origListReleases := bundleListGitHubReleases
+	origTTY := bundleInputIsTTY
+	defer func() {
+		bundlePreset = origPreset
+		bundleVersion = origVersion
+		bundleListGitHubReleases = origListReleases
+		bundleInputIsTTY = origTTY
+	}()
+
+	bundlePreset = "test"
+	bundleVersion = ""
+	bundleInputIsTTY = func() bool { return false }
+	bundleListGitHubReleases = func(string) ([]bundle.GitHubReleaseVersion, error) {
+		return []bundle.GitHubReleaseVersion{{TagName: "v1.3.0", Prerelease: false}, {TagName: "v1.4.0-alpha.1", Prerelease: true}}, nil
+	}
+
+	err := runBundleApply("github1")
+	if err == nil {
+		t.Fatal("runBundleApply() error = nil, want version-selection error")
+	}
+	if !strings.Contains(err.Error(), "--version is required for github-release sources outside interactive mode") {
+		t.Fatalf("runBundleApply() error = %v", err)
+	}
+}
+
+func TestBundleApplyGitHubSourceReportsPrereleaseOnlyOutsideInteractiveMode(t *testing.T) {
+	restore := saveRegistry(t)
+	defer restore()
+
+	registry, _ := source.LoadRegistry()
+	registry.Sources = []source.Source{{
+		ID:       "github1",
+		Location: "qbicsoftware/opencode-config-bundle",
+		Type:     source.SourceTypeGitHubRelease,
+		Name:     "qbic",
+	}}
+	if err := source.SaveRegistry(registry); err != nil {
+		t.Fatalf("failed to save registry: %v", err)
+	}
+
+	origPreset := bundlePreset
+	origVersion := bundleVersion
+	origListReleases := bundleListGitHubReleases
+	origTTY := bundleInputIsTTY
+	defer func() {
+		bundlePreset = origPreset
+		bundleVersion = origVersion
+		bundleListGitHubReleases = origListReleases
+		bundleInputIsTTY = origTTY
+	}()
+
+	bundlePreset = "test"
+	bundleVersion = ""
+	bundleInputIsTTY = func() bool { return false }
+	bundleListGitHubReleases = func(string) ([]bundle.GitHubReleaseVersion, error) {
+		return []bundle.GitHubReleaseVersion{{TagName: "v1.4.0-alpha.1", Prerelease: true}, {TagName: "v1.3.0-alpha.2", Prerelease: true}}, nil
+	}
+
+	err := runBundleApply("github1")
+	if err == nil {
+		t.Fatal("runBundleApply() error = nil, want prerelease-only version-selection error")
+	}
+	if !strings.Contains(err.Error(), "only prereleases are available") {
+		t.Fatalf("runBundleApply() error = %v", err)
+	}
+}
+
 // TestBundleApplyFlags tests that bundle apply flags are properly configured
 func TestBundleApplyFlags(t *testing.T) {
 	if bundleApplyCmd.Flags().Lookup("preset") == nil {

--- a/cmd/preset.go
+++ b/cmd/preset.go
@@ -104,7 +104,16 @@ func runSourcePresetList() error {
 
 	foundPreset := false
 	for _, src := range sources {
-		bundleRoot, cleanup, err := presetResolveToLocal(string(src.Type), src.Location, "")
+		versionTag := ""
+		if string(src.Type) == "github-release" {
+			versionTag, err = resolveGitHubBundleVersion(src.Location, "")
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "warning: failed to inspect source %s (%s): %v\n", src.Name, src.ID, err)
+				continue
+			}
+		}
+
+		bundleRoot, cleanup, err := presetResolveToLocal(string(src.Type), src.Location, versionTag)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "warning: failed to inspect source %s (%s): %v\n", src.Name, src.ID, err)
 			continue

--- a/cmd/preset.go
+++ b/cmd/preset.go
@@ -106,7 +106,7 @@ func runSourcePresetList() error {
 	for _, src := range sources {
 		versionTag := ""
 		if string(src.Type) == "github-release" {
-			versionTag, err = resolveGitHubBundleVersion(src.Location, "")
+			versionTag, err = inspectGitHubBundleVersion(src.Location, "")
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "warning: failed to inspect source %s (%s): %v\n", src.Name, src.ID, err)
 				continue

--- a/cmd/preset_test.go
+++ b/cmd/preset_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sven1103-agent/opencode-config-cli/internal/bundle"
 	"github.com/sven1103-agent/opencode-config-cli/internal/source"
 )
 
@@ -130,5 +131,143 @@ func TestRunPresetListSources(t *testing.T) {
 	stdout := string(stdoutBytes)
 	if !strings.Contains(stdout, "qbic") || !strings.Contains(stdout, "v1.2.3") || !strings.Contains(stdout, "mixed") {
 		t.Fatalf("stdout = %s", stdout)
+	}
+}
+
+func TestRunPresetListSourcesGitHubUsesLatestStableInspection(t *testing.T) {
+	restore := saveRegistry(t)
+	defer restore()
+
+	registry, _ := source.LoadRegistry()
+	registry.Sources = []source.Source{{ID: "id-1", Name: "qbic", Type: source.SourceTypeGitHubRelease, Location: "qbicsoftware/opencode-config-bundle"}}
+	if err := source.SaveRegistry(registry); err != nil {
+		t.Fatalf("failed to save registry: %v", err)
+	}
+
+	origResolve := presetResolveToLocal
+	origListReleases := bundleListGitHubReleases
+	origTTY := bundleInputIsTTY
+	origStdout := os.Stdout
+	origStderr := os.Stderr
+	defer func() {
+		presetResolveToLocal = origResolve
+		bundleListGitHubReleases = origListReleases
+		bundleInputIsTTY = origTTY
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+	}()
+
+	bundleInputIsTTY = func() bool { return true }
+	bundleListGitHubReleases = func(string) ([]bundle.GitHubReleaseVersion, error) {
+		return []bundle.GitHubReleaseVersion{{TagName: "v2.0.0-alpha.1", Prerelease: true}, {TagName: "v1.9.0", Prerelease: false}}, nil
+	}
+	presetResolveToLocal = func(sourceType, sourceLocation, versionTag string) (string, func(), error) {
+		if versionTag != "v1.9.0" {
+			t.Fatalf("versionTag = %q, want latest stable", versionTag)
+		}
+		bundleDir := t.TempDir()
+		manifest := `{"manifest_version":"1.0.0","bundle_name":"qbic","bundle_version":"v1.9.0","presets":[{"name":"mixed","entrypoint":"mixed.json","description":"Mixed preset"}]}`
+		if err := os.WriteFile(filepath.Join(bundleDir, "opencode-bundle.manifest.json"), []byte(manifest), 0644); err != nil {
+			return "", nil, err
+		}
+		if err := os.WriteFile(filepath.Join(bundleDir, "mixed.json"), []byte(`{"agents":[]}`), 0644); err != nil {
+			return "", nil, err
+		}
+		return bundleDir, func() {}, nil
+	}
+
+	rOut, wOut, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create stdout pipe: %v", err)
+	}
+	rErr, wErr, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create stderr pipe: %v", err)
+	}
+	os.Stdout = wOut
+	os.Stderr = wErr
+
+	err = runSourcePresetList()
+	wOut.Close()
+	wErr.Close()
+	if err != nil {
+		t.Fatalf("runSourcePresetList() error = %v", err)
+	}
+
+	stdoutBytes, _ := io.ReadAll(rOut)
+	stderrBytes, _ := io.ReadAll(rErr)
+	if len(stderrBytes) != 0 {
+		t.Fatalf("stderr = %s", stderrBytes)
+	}
+	stdout := string(stdoutBytes)
+	if !strings.Contains(stdout, "v1.9.0") || !strings.Contains(stdout, "mixed") {
+		t.Fatalf("stdout = %s", stdout)
+	}
+}
+
+func TestRunPresetListSourcesGitHubPrereleaseOnlyWarnsWithoutPrompting(t *testing.T) {
+	restore := saveRegistry(t)
+	defer restore()
+
+	registry, _ := source.LoadRegistry()
+	registry.Sources = []source.Source{{ID: "id-1", Name: "qbic", Type: source.SourceTypeGitHubRelease, Location: "qbicsoftware/opencode-config-bundle"}}
+	if err := source.SaveRegistry(registry); err != nil {
+		t.Fatalf("failed to save registry: %v", err)
+	}
+
+	origResolve := presetResolveToLocal
+	origListReleases := bundleListGitHubReleases
+	origTTY := bundleInputIsTTY
+	origStdout := os.Stdout
+	origStderr := os.Stderr
+	defer func() {
+		presetResolveToLocal = origResolve
+		bundleListGitHubReleases = origListReleases
+		bundleInputIsTTY = origTTY
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+	}()
+
+	bundleInputIsTTY = func() bool { return true }
+	bundleListGitHubReleases = func(string) ([]bundle.GitHubReleaseVersion, error) {
+		return []bundle.GitHubReleaseVersion{{TagName: "v2.0.0-alpha.1", Prerelease: true}}, nil
+	}
+	resolveCalled := false
+	presetResolveToLocal = func(sourceType, sourceLocation, versionTag string) (string, func(), error) {
+		resolveCalled = true
+		return "", nil, nil
+	}
+
+	rOut, wOut, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create stdout pipe: %v", err)
+	}
+	rErr, wErr, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create stderr pipe: %v", err)
+	}
+	os.Stdout = wOut
+	os.Stderr = wErr
+
+	err = runSourcePresetList()
+	wOut.Close()
+	wErr.Close()
+	if err == nil {
+		t.Fatal("runSourcePresetList() error = nil, want no inspectable presets error")
+	}
+	if !strings.Contains(err.Error(), "no inspectable source presets found") {
+		t.Fatalf("runSourcePresetList() error = %v", err)
+	}
+	if resolveCalled {
+		t.Fatal("preset list should not resolve prerelease-only github source without explicit version")
+	}
+
+	stdoutBytes, _ := io.ReadAll(rOut)
+	stderrBytes, _ := io.ReadAll(rErr)
+	if len(stdoutBytes) == 0 {
+		t.Fatal("expected table header on stdout")
+	}
+	if !strings.Contains(string(stderrBytes), "no stable release found") {
+		t.Fatalf("stderr = %s", stderrBytes)
 	}
 }

--- a/docs/specs/cli-e2e-coverage.md
+++ b/docs/specs/cli-e2e-coverage.md
@@ -53,6 +53,9 @@ It is the durable inventory for what is already covered, what is verified in CI,
 | List registered sources | `oc source list` | registry | Implemented | ✅ | Covered inside the local directory flow |
 | Apply preset from local directory source | `oc bundle apply <id> --preset <name>` | local directory | Implemented | ✅ | Verifies written config and provenance |
 | Apply preset from local archive source | `oc bundle apply <id> --preset <name>` | local archive | Implemented | ✅ | Exercises tar extraction path |
+| Apply preset from GitHub release source with explicit version | `oc bundle apply <id> --version <tag> --preset <name>` | GitHub release | Implemented | ✅ | Uses `httptest` remote and checksum verification |
+| Apply preset from GitHub release source with interactive version selection | `oc bundle apply <id> --preset <name>` in PTY session | GitHub release | Implemented | ✅ | Verifies version prompt, prerelease labeling, and provenance for selected release |
+| Refuse non-interactive GitHub apply without `--version` when multiple releases exist | `oc bundle apply <id> --preset <name>` | GitHub release | Implemented | ✅ | Verifies actionable error and no prompt leakage in non-interactive mode |
 | Show applied bundle provenance | `oc bundle status --project-root <dir>` | project provenance | Implemented | ✅ | Reads `.opencode/bundle-provenance.json` through CLI |
 | Refuse overwrite without force | `oc bundle apply <id> --preset <name>` | local directory | Implemented | ✅ | Must fail when output already exists |
 | Reject missing manifest source | `oc source add <dir>` | invalid local directory | Implemented | ✅ | Validates manifest presence check |
@@ -63,10 +66,9 @@ It is the durable inventory for what is already covered, what is verified in CI,
 
 | Gap | Reason | Planned Follow-up |
 |---|---|---|
-| GitHub release source E2E | Current implementation still has remote operations marked not implemented in this branch line | Add once remote source behavior is stable end to end |
-| `httptest`-backed remote source coverage | Not needed for initial local-flow milestone | Add with remote-source implementation follow-up |
 | `bundle update` E2E | Current command behavior is intentionally limited and network-dependent | Add when update behavior is production-ready |
 | Windows runner coverage | Windows is out of current scope | Revisit only if product scope changes |
+| GitHub release source list/update edge cases | Basic apply flows are covered, but source listing and future update UX still need broader remote-source E2E | Extend when update behavior and broader source-capability UX are finalized |
 
 ## Fixture Strategy
 
@@ -87,3 +89,4 @@ It is the durable inventory for what is already covered, what is verified in CI,
 - 2026-04-01: Document created for `US-052` initial local-flow coverage planning
 - 2026-04-01: Initial local-flow scenarios implemented in `e2e/` and wired into `.github/workflows/e2e-cli.yml`
 - 2026-04-01: Marked initial local-flow scenarios as CI-verified after successful `main` workflow run `23850747833` on Linux and macOS
+- 2026-04-09: Marked GitHub release apply coverage as implemented for explicit `--version`, interactive version selection, and non-interactive version-selection failure paths

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -8,15 +8,19 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/creack/pty"
 )
 
 type commandResult struct {
@@ -149,39 +153,12 @@ func TestLocalArchiveFlow(t *testing.T) {
 func TestGitHubReleaseFlow(t *testing.T) {
 	env := testEnv(t)
 	projectRoot := t.TempDir()
-	bundleDir := filepath.Join(t.TempDir(), "opencode-config-bundle-v1.2.3")
-	if err := os.MkdirAll(bundleDir, 0o755); err != nil {
-		t.Fatalf("failed to create bundle dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(bundleDir, "opencode-bundle.manifest.json"), []byte(`{
-		"manifest_version": "1.0.0",
-		"bundle_name": "fixture-github",
-		"bundle_version": "v1.2.3",
-		"presets": [
-			{"name": "fixture", "entrypoint": "opencode.json"}
-		]
-	}`), 0o644); err != nil {
-		t.Fatalf("failed to write manifest: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(bundleDir, "opencode.json"), []byte(`{"mode":"github-fixture"}`), 0o644); err != nil {
-		t.Fatalf("failed to write preset: %v", err)
-	}
-
-	archivePath := filepath.Join(t.TempDir(), "opencode-config-bundle-v1.2.3.tar.gz")
-	createTarGzFromDir(t, bundleDir, archivePath)
-	archiveData, err := os.ReadFile(archivePath)
-	if err != nil {
-		t.Fatalf("failed to read archive: %v", err)
-	}
-	archiveSHA := fmt.Sprintf("%x", sha256.Sum256(archiveData))
-	checksums := fmt.Sprintf("%s  %s\n", archiveSHA, filepath.Base(archivePath))
 
 	server := newGitHubReleaseE2EServer(t, githubReleaseE2EFixture{
-		repo:         "owner/repo",
-		tag:          "v1.2.3",
-		archiveName:  filepath.Base(archivePath),
-		archiveBytes: archiveData,
-		checksums:    checksums,
+		repo: "owner/repo",
+		releases: []githubReleaseE2ERelease{
+			newGitHubReleaseE2ERelease(t, "v1.2.3", false, "github-fixture"),
+		},
 	})
 	defer server.Close()
 
@@ -210,6 +187,70 @@ func TestGitHubReleaseFlow(t *testing.T) {
 	}
 	if prov.SourceName != "fixture-github" {
 		t.Fatalf("expected source name fixture-github, got %q", prov.SourceName)
+	}
+}
+
+func TestGitHubReleaseInteractiveVersionSelectionFlow(t *testing.T) {
+	env := testEnv(t)
+	projectRoot := t.TempDir()
+	server := newGitHubReleaseE2EServer(t, githubReleaseE2EFixture{
+		repo: "owner/repo",
+		releases: []githubReleaseE2ERelease{
+			newGitHubReleaseE2ERelease(t, "v1.3.0-alpha.1", true, "github-prerelease"),
+			newGitHubReleaseE2ERelease(t, "v1.2.3", false, "github-stable"),
+		},
+	})
+	defer server.Close()
+
+	env = append(env, "OC_GITHUB_API_BASE_URL="+server.URL)
+
+	addResult := runOC(t, env, "source", "add", "owner/repo", "--name", "fixture-github")
+	requireSuccess(t, addResult)
+	sourceID := extractSourceID(t, addResult.stdout)
+
+	applyResult := runOCInPTY(t, env, "1\n", "bundle", "apply", sourceID, "--preset", "fixture", "--project-root", projectRoot)
+	requireSuccess(t, applyResult)
+	requireContains(t, applyResult.stdout, "Available versions for owner/repo:")
+	requireContains(t, applyResult.stdout, "v1.3.0-alpha.1 (prerelease)")
+
+	configData, err := os.ReadFile(filepath.Join(projectRoot, "opencode.json"))
+	if err != nil {
+		t.Fatalf("failed to read applied config: %v", err)
+	}
+	requireContains(t, string(configData), `"mode":"github-prerelease"`)
+
+	prov := readProvenance(t, filepath.Join(projectRoot, ".opencode", "bundle-provenance.json"))
+	if prov.BundleVersion != "v1.3.0-alpha.1" {
+		t.Fatalf("expected bundle version v1.3.0-alpha.1, got %q", prov.BundleVersion)
+	}
+	if prov.PresetName != "fixture" {
+		t.Fatalf("expected preset fixture, got %q", prov.PresetName)
+	}
+}
+
+func TestGitHubReleaseApplyWithoutVersionNonInteractiveFails(t *testing.T) {
+	env := testEnv(t)
+	projectRoot := t.TempDir()
+	server := newGitHubReleaseE2EServer(t, githubReleaseE2EFixture{
+		repo: "owner/repo",
+		releases: []githubReleaseE2ERelease{
+			newGitHubReleaseE2ERelease(t, "v1.3.0-alpha.1", true, "github-prerelease"),
+			newGitHubReleaseE2ERelease(t, "v1.2.3", false, "github-stable"),
+		},
+	})
+	defer server.Close()
+
+	env = append(env, "OC_GITHUB_API_BASE_URL="+server.URL)
+
+	addResult := runOC(t, env, "source", "add", "owner/repo", "--name", "fixture-github")
+	requireSuccess(t, addResult)
+	sourceID := extractSourceID(t, addResult.stdout)
+
+	applyResult := runOCWithStdin(t, env, strings.NewReader(""), "bundle", "apply", sourceID, "--preset", "fixture", "--project-root", projectRoot)
+	requireFailure(t, applyResult)
+	requireContains(t, applyResult.stderr, "--version is required for github-release sources outside interactive mode")
+	if strings.Contains(applyResult.stderr, "Select a version") || strings.Contains(applyResult.stdout, "Select a version") {
+		t.Fatalf("unexpected interactive prompt in non-interactive flow: stdout=%q stderr=%q", applyResult.stdout, applyResult.stderr)
 	}
 }
 
@@ -285,6 +326,43 @@ func testEnv(t *testing.T) []string {
 func runOC(t *testing.T, env []string, args ...string) commandResult {
 	t.Helper()
 	return runOCWithStdin(t, env, nil, args...)
+}
+
+func runOCInPTY(t *testing.T, env []string, input string, args ...string) commandResult {
+	t.Helper()
+	binaryPath := os.Getenv("OC_E2E_BINARY")
+	if binaryPath == "" {
+		t.Skip("OC_E2E_BINARY not set; skipping black-box CLI E2E tests")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, binaryPath, args...)
+	cmd.Env = env
+	ptmx, err := pty.Start(cmd)
+	if err != nil {
+		t.Fatalf("failed to start PTY command: %v", err)
+	}
+	defer ptmx.Close()
+
+	var output bytes.Buffer
+	readDone := make(chan error, 1)
+	go func() {
+		_, copyErr := io.Copy(&output, ptmx)
+		readDone <- copyErr
+	}()
+
+	if input != "" {
+		if _, err := ptmx.Write([]byte(input)); err != nil {
+			t.Fatalf("failed to write PTY input: %v", err)
+		}
+	}
+	err = cmd.Wait()
+	_ = ptmx.Close()
+	<-readDone
+
+	return commandResult{stdout: output.String(), stderr: output.String(), err: err}
 }
 
 func runOCWithStdin(t *testing.T, env []string, stdin *strings.Reader, args ...string) commandResult {
@@ -456,8 +534,13 @@ func createTarGzFromDir(t *testing.T, sourceDir, archivePath string) {
 }
 
 type githubReleaseE2EFixture struct {
-	repo         string
+	repo     string
+	releases []githubReleaseE2ERelease
+}
+
+type githubReleaseE2ERelease struct {
 	tag          string
+	prerelease   bool
 	archiveName  string
 	archiveBytes []byte
 	checksums    string
@@ -466,36 +549,105 @@ type githubReleaseE2EFixture struct {
 func newGitHubReleaseE2EServer(t *testing.T, fixture githubReleaseE2EFixture) *httptest.Server {
 	t.Helper()
 	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/"+fixture.repo+"/releases", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(buildReleaseListResponse(r.Host, fixture.releases))
+	})
 	mux.HandleFunc("/repos/"+fixture.repo+"/releases/latest", func(w http.ResponseWriter, r *http.Request) {
-		writeReleaseResponse(w, r, fixture)
+		for _, release := range fixture.releases {
+			if release.prerelease {
+				continue
+			}
+			writeReleaseResponse(w, r, fixture.repo, release)
+			return
+		}
+		http.NotFound(w, r)
 	})
-	mux.HandleFunc("/repos/"+fixture.repo+"/releases/tags/"+fixture.tag, func(w http.ResponseWriter, r *http.Request) {
-		writeReleaseResponse(w, r, fixture)
-	})
-	mux.HandleFunc("/downloads/"+fixture.repo+"/releases/download/"+fixture.tag+"/"+fixture.archiveName, func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/gzip")
-		_, _ = w.Write(fixture.archiveBytes)
-	})
-	mux.HandleFunc("/downloads/"+fixture.repo+"/releases/download/"+fixture.tag+"/opencode-config-bundle-"+fixture.tag+"-checksums.txt", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/plain")
-		_, _ = w.Write([]byte(fixture.checksums))
-	})
+	for _, release := range fixture.releases {
+		release := release
+		mux.HandleFunc("/repos/"+fixture.repo+"/releases/tags/"+release.tag, func(w http.ResponseWriter, r *http.Request) {
+			writeReleaseResponse(w, r, fixture.repo, release)
+		})
+		mux.HandleFunc("/downloads/"+fixture.repo+"/releases/download/"+release.tag+"/"+release.archiveName, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/gzip")
+			_, _ = w.Write(release.archiveBytes)
+		})
+		mux.HandleFunc("/downloads/"+fixture.repo+"/releases/download/"+release.tag+"/opencode-config-bundle-"+release.tag+"-checksums.txt", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/plain")
+			_, _ = w.Write([]byte(release.checksums))
+		})
+	}
 	return httptest.NewServer(mux)
 }
 
-func writeReleaseResponse(w http.ResponseWriter, r *http.Request, fixture githubReleaseE2EFixture) {
+func writeReleaseResponse(w http.ResponseWriter, r *http.Request, repo string, release githubReleaseE2ERelease) {
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]any{
-		"tag_name": fixture.tag,
+		"tag_name":   release.tag,
+		"prerelease": release.prerelease,
 		"assets": []map[string]string{
 			{
-				"name":                 fixture.archiveName,
-				"browser_download_url": fmt.Sprintf("http://%s/downloads/%s/releases/download/%s/%s", r.Host, fixture.repo, fixture.tag, fixture.archiveName),
+				"name":                 release.archiveName,
+				"browser_download_url": fmt.Sprintf("http://%s/downloads/%s/releases/download/%s/%s", r.Host, repo, release.tag, release.archiveName),
 			},
 			{
-				"name":                 "opencode-config-bundle-" + fixture.tag + "-checksums.txt",
-				"browser_download_url": fmt.Sprintf("http://%s/downloads/%s/releases/download/%s/%s", r.Host, fixture.repo, fixture.tag, "opencode-config-bundle-"+fixture.tag+"-checksums.txt"),
+				"name":                 "opencode-config-bundle-" + release.tag + "-checksums.txt",
+				"browser_download_url": fmt.Sprintf("http://%s/downloads/%s/releases/download/%s/%s", r.Host, repo, release.tag, "opencode-config-bundle-"+release.tag+"-checksums.txt"),
 			},
 		},
 	})
+}
+
+func buildReleaseListResponse(host string, releases []githubReleaseE2ERelease) []map[string]any {
+	responses := make([]map[string]any, 0, len(releases))
+	for _, release := range releases {
+		responses = append(responses, map[string]any{
+			"tag_name":   release.tag,
+			"prerelease": release.prerelease,
+			"assets": []map[string]string{{
+				"name":                 release.archiveName,
+				"browser_download_url": fmt.Sprintf("http://%s/downloads/unused/releases/download/%s/%s", host, release.tag, release.archiveName),
+			}},
+		})
+	}
+	sort.SliceStable(responses, func(i, j int) bool { return i < j })
+	return responses
+}
+
+func newGitHubReleaseE2ERelease(t *testing.T, tag string, prerelease bool, mode string) githubReleaseE2ERelease {
+	t.Helper()
+	bundleDir := filepath.Join(t.TempDir(), "opencode-config-bundle-"+tag)
+	if err := os.MkdirAll(bundleDir, 0o755); err != nil {
+		t.Fatalf("failed to create bundle dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(bundleDir, "opencode-bundle.manifest.json"), []byte(fmt.Sprintf(`{
+		"manifest_version": "1.0.0",
+		"bundle_name": "fixture-github",
+		"bundle_version": %q,
+		"presets": [
+			{"name": "fixture", "entrypoint": "opencode.json"}
+		]
+	}`, tag)), 0o644); err != nil {
+		t.Fatalf("failed to write manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(bundleDir, "opencode.json"), []byte(fmt.Sprintf(`{"mode":"%s"}`, mode)), 0o644); err != nil {
+		t.Fatalf("failed to write preset: %v", err)
+	}
+
+	archiveName := "opencode-config-bundle-" + tag + ".tar.gz"
+	archivePath := filepath.Join(t.TempDir(), archiveName)
+	createTarGzFromDir(t, bundleDir, archivePath)
+	archiveData, err := os.ReadFile(archivePath)
+	if err != nil {
+		t.Fatalf("failed to read archive: %v", err)
+	}
+	archiveSHA := fmt.Sprintf("%x", sha256.Sum256(archiveData))
+
+	return githubReleaseE2ERelease{
+		tag:          tag,
+		prerelease:   prerelease,
+		archiveName:  archiveName,
+		archiveBytes: archiveData,
+		checksums:    fmt.Sprintf("%s  %s\n", archiveSHA, archiveName),
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 )
 
 require (
+	github.com/creack/pty v1.1.24 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -212,13 +212,20 @@ func ResolveToLocal(sourceType, sourceLocation, versionTag string) (string, func
 }
 
 type githubReleaseResponse struct {
-	TagName string               `json:"tag_name"`
-	Assets  []githubReleaseAsset `json:"assets"`
+	TagName    string               `json:"tag_name"`
+	Prerelease bool                 `json:"prerelease"`
+	Assets     []githubReleaseAsset `json:"assets"`
 }
 
 type githubReleaseAsset struct {
 	Name               string `json:"name"`
 	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+// GitHubReleaseVersion describes a GitHub release version available for a bundle source.
+type GitHubReleaseVersion struct {
+	TagName    string
+	Prerelease bool
 }
 
 func resolveGitHubReleaseToLocal(sourceLocation, versionTag string) (string, error) {
@@ -232,7 +239,7 @@ func resolveGitHubReleaseToLocal(sourceLocation, versionTag string) (string, err
 		tag = ref.Tag
 	}
 	if tag == "" {
-		tag = "latest"
+		return "", fmt.Errorf("--version is required for github-release sources outside interactive mode (use --version latest or --version <tag>)")
 	}
 
 	release, err := fetchGitHubRelease(ref.Repo, tag)
@@ -316,15 +323,96 @@ func cachedBundleRoot(cachedExtract string) (string, error) {
 	return findBundleRoot(cachedExtract)
 }
 
+// ListGitHubReleases returns usable GitHub bundle releases for a source location.
+func ListGitHubReleases(sourceLocation string) ([]GitHubReleaseVersion, error) {
+	ref, err := source.ParseGitHubLocation(sourceLocation)
+	if err != nil {
+		return nil, err
+	}
+
+	releases, err := fetchGitHubReleases(ref.Repo)
+	if err != nil {
+		return nil, err
+	}
+
+	versions := make([]GitHubReleaseVersion, 0, len(releases))
+	for _, release := range releases {
+		if archiveAsset, _ := selectGitHubAssets(release); archiveAsset == nil {
+			continue
+		}
+		versions = append(versions, GitHubReleaseVersion{TagName: release.TagName, Prerelease: release.Prerelease})
+	}
+
+	if len(versions) == 0 {
+		return nil, fmt.Errorf("no usable bundle releases found for %s", ref.Repo)
+	}
+
+	return versions, nil
+}
+
 func fetchGitHubRelease(repo, tag string) (*githubReleaseResponse, error) {
+	if tag == "latest" {
+		releases, err := fetchGitHubReleases(repo)
+		if err != nil {
+			return nil, err
+		}
+
+		var sawPrerelease bool
+		for _, release := range releases {
+			if release.Prerelease {
+				sawPrerelease = true
+				continue
+			}
+			return fetchGitHubReleaseFromPath("/repos/" + repo + "/releases/tags/" + release.TagName)
+		}
+
+		if sawPrerelease {
+			return nil, fmt.Errorf("no stable release found for %s; prereleases are available (use --version <tag>)", repo)
+		}
+		return nil, fmt.Errorf("no releases found for %s", repo)
+	}
+
+	path := "/repos/" + repo + "/releases/tags/" + tag
+	return fetchGitHubReleaseFromPath(path)
+}
+
+func fetchGitHubReleases(repo string) ([]*githubReleaseResponse, error) {
+	path := "/repos/" + repo + "/releases?per_page=100"
+	body, err := fetchGitHubReleaseBody(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var releases []*githubReleaseResponse
+	if err := json.Unmarshal(body, &releases); err != nil {
+		return nil, fmt.Errorf("failed to parse releases response: %w", err)
+	}
+	if len(releases) == 0 {
+		return nil, fmt.Errorf("no releases found for %s", repo)
+	}
+	return releases, nil
+}
+
+func fetchGitHubReleaseFromPath(path string) (*githubReleaseResponse, error) {
+	body, err := fetchGitHubReleaseBody(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var release githubReleaseResponse
+	if err := json.Unmarshal(body, &release); err != nil {
+		return nil, fmt.Errorf("failed to parse release response: %w", err)
+	}
+	if release.TagName == "" {
+		return nil, fmt.Errorf("failed to parse tag_name from release")
+	}
+	return &release, nil
+}
+
+func fetchGitHubReleaseBody(path string) ([]byte, error) {
 	apiBase := githubAPIBaseURL
 	if envBase := os.Getenv("OC_GITHUB_API_BASE_URL"); envBase != "" {
 		apiBase = envBase
-	}
-
-	path := "/repos/" + repo + "/releases/latest"
-	if tag != "latest" {
-		path = "/repos/" + repo + "/releases/tags/" + tag
 	}
 
 	resp, err := githubHTTPClient.Get(strings.TrimRight(apiBase, "/") + path)
@@ -342,14 +430,11 @@ func fetchGitHubRelease(repo, tag string) (*githubReleaseResponse, error) {
 		return nil, fmt.Errorf("GitHub API error: %s", msg)
 	}
 
-	var release githubReleaseResponse
-	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
-		return nil, fmt.Errorf("failed to parse release response: %w", err)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read release response: %w", err)
 	}
-	if release.TagName == "" {
-		return nil, fmt.Errorf("failed to parse tag_name from release")
-	}
-	return &release, nil
+	return body, nil
 }
 
 func selectGitHubAssets(release *githubReleaseResponse) (*githubReleaseAsset, *githubReleaseAsset) {

--- a/internal/bundle/github_release_test.go
+++ b/internal/bundle/github_release_test.go
@@ -14,6 +14,85 @@ import (
 )
 
 func TestResolveToLocal_GitHubRelease(t *testing.T) {
+	t.Run("resolves latest stable release when prereleases also exist", func(t *testing.T) {
+		archiveBytes := buildBundleArchive(t, archiveFixture{tag: "v1.2.3", bundleVersion: "v1.2.3", presetName: "mixed"})
+		checksum := sha256Hex(archiveBytes)
+
+		server := newGitHubReleaseTestServer(t, githubReleaseServerFixture{
+			repo:         "qbicsoftware/opencode-config-bundle",
+			tag:          "v1.2.3",
+			archiveBytes: archiveBytes,
+			checksums:    fmt.Sprintf("%s  opencode-config-bundle-v1.2.3.tar.gz\n", checksum),
+			releases:     []githubReleaseFixture{{Tag: "v1.3.0-alpha.1", Prerelease: true}, {Tag: "v1.2.3", Prerelease: false}},
+		})
+		defer server.Close()
+
+		oldClient := githubHTTPClient
+		oldAPIBaseURL := githubAPIBaseURL
+		oldDownloadBaseURL := githubDownloadBaseURL
+		oldCacheDir := githubCacheDirOverride
+		githubHTTPClient = server.Client()
+		githubAPIBaseURL = server.URL
+		githubDownloadBaseURL = server.URL
+		githubCacheDirOverride = t.TempDir()
+		defer func() {
+			githubHTTPClient = oldClient
+			githubAPIBaseURL = oldAPIBaseURL
+			githubDownloadBaseURL = oldDownloadBaseURL
+			githubCacheDirOverride = oldCacheDir
+		}()
+
+		bundleRoot, cleanup, err := ResolveToLocal("github-release", "qbicsoftware/opencode-config-bundle", "latest")
+		if err != nil {
+			t.Fatalf("ResolveToLocal() error = %v", err)
+		}
+		defer cleanup()
+
+		manifestPath := filepath.Join(bundleRoot, "opencode-bundle.manifest.json")
+		manifestBytes, err := os.ReadFile(manifestPath)
+		if err != nil {
+			t.Fatalf("expected manifest at %s: %v", manifestPath, err)
+		}
+		if !strings.Contains(string(manifestBytes), `"bundle_version": "v1.2.3"`) {
+			t.Fatalf("manifest = %s", manifestBytes)
+		}
+	})
+
+	t.Run("latest reports prerelease-only repositories clearly", func(t *testing.T) {
+		server := newGitHubReleaseTestServer(t, githubReleaseServerFixture{
+			repo:     "qbicsoftware/opencode-config-bundle",
+			tag:      "v1.3.0-alpha.1",
+			releases: []githubReleaseFixture{{Tag: "v1.3.0-alpha.1", Prerelease: true}},
+		})
+		defer server.Close()
+
+		oldClient := githubHTTPClient
+		oldAPIBaseURL := githubAPIBaseURL
+		oldDownloadBaseURL := githubDownloadBaseURL
+		oldCacheDir := githubCacheDirOverride
+		githubHTTPClient = server.Client()
+		githubAPIBaseURL = server.URL
+		githubDownloadBaseURL = server.URL
+		githubCacheDirOverride = t.TempDir()
+		defer func() {
+			githubHTTPClient = oldClient
+			githubAPIBaseURL = oldAPIBaseURL
+			githubDownloadBaseURL = oldDownloadBaseURL
+			githubCacheDirOverride = oldCacheDir
+		}()
+
+		_, cleanup, err := ResolveToLocal("github-release", "qbicsoftware/opencode-config-bundle", "latest")
+		if cleanup != nil {
+			defer cleanup()
+		}
+		if err == nil {
+			t.Fatal("ResolveToLocal() error = nil, want prerelease-only failure")
+		}
+		if !strings.Contains(err.Error(), "prereleases are available") {
+			t.Fatalf("ResolveToLocal() error = %v", err)
+		}
+	})
+
 	t.Run("resolves tagged release and verifies checksum", func(t *testing.T) {
 		archiveBytes := buildBundleArchive(t, archiveFixture{tag: "v1.2.3", bundleVersion: "v1.2.3", presetName: "mixed"})
 		checksum := sha256Hex(archiveBytes)
@@ -127,6 +206,38 @@ func TestResolveToLocal_GitHubRelease(t *testing.T) {
 	})
 }
 
+func TestListGitHubReleases(t *testing.T) {
+	server := newGitHubReleaseTestServer(t, githubReleaseServerFixture{
+		repo:     "qbicsoftware/opencode-config-bundle",
+		tag:      "v1.2.3",
+		releases: []githubReleaseFixture{{Tag: "v1.3.0-alpha.1", Prerelease: true}, {Tag: "v1.2.3", Prerelease: false}},
+	})
+	defer server.Close()
+
+	oldClient := githubHTTPClient
+	oldAPIBaseURL := githubAPIBaseURL
+	githubHTTPClient = server.Client()
+	githubAPIBaseURL = server.URL
+	defer func() {
+		githubHTTPClient = oldClient
+		githubAPIBaseURL = oldAPIBaseURL
+	}()
+
+	releases, err := ListGitHubReleases("qbicsoftware/opencode-config-bundle")
+	if err != nil {
+		t.Fatalf("ListGitHubReleases() error = %v", err)
+	}
+	if len(releases) != 2 {
+		t.Fatalf("len(releases) = %d, want 2", len(releases))
+	}
+	if releases[0].TagName != "v1.3.0-alpha.1" || !releases[0].Prerelease {
+		t.Fatalf("releases[0] = %+v", releases[0])
+	}
+	if releases[1].TagName != "v1.2.3" || releases[1].Prerelease {
+		t.Fatalf("releases[1] = %+v", releases[1])
+	}
+}
+
 type archiveFixture struct {
 	tag           string
 	bundleVersion string
@@ -176,6 +287,12 @@ type githubReleaseServerFixture struct {
 	tag          string
 	archiveBytes []byte
 	checksums    string
+	releases     []githubReleaseFixture
+}
+
+type githubReleaseFixture struct {
+	Tag        string
+	Prerelease bool
 }
 
 func newGitHubReleaseTestServer(t *testing.T, fixture githubReleaseServerFixture) *httptest.Server {
@@ -183,6 +300,10 @@ func newGitHubReleaseTestServer(t *testing.T, fixture githubReleaseServerFixture
 
 	archiveName := fmt.Sprintf("opencode-config-bundle-%s.tar.gz", fixture.tag)
 	handler := http.NewServeMux()
+	handler.HandleFunc("/repos/"+fixture.repo+"/releases", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(buildReleasesJSON(fixture)))
+	})
 
 	handler.HandleFunc("/repos/"+fixture.repo+"/releases/tags/"+fixture.tag, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -214,11 +335,12 @@ func newGitHubReleaseTestServer(t *testing.T, fixture githubReleaseServerFixture
 
 func buildReleaseJSON(baseURL string, fixture githubReleaseServerFixture, archiveName string) string {
 	if len(fixture.archiveBytes) == 0 {
-		return fmt.Sprintf(`{"tag_name":%q,"assets":[]}`, fixture.tag)
+		return fmt.Sprintf(`{"tag_name":%q,"prerelease":false,"assets":[]}`, fixture.tag)
 	}
 
 	return fmt.Sprintf(`{
 		"tag_name": %q,
+		"prerelease": false,
 		"assets": [
 			{"name": %q, "browser_download_url": %q},
 			{"name": %q, "browser_download_url": %q}
@@ -230,4 +352,19 @@ func buildReleaseJSON(baseURL string, fixture githubReleaseServerFixture, archiv
 		"opencode-config-bundle-"+fixture.tag+"-checksums.txt",
 		fmt.Sprintf("%s/downloads/%s/releases/download/%s/%s", baseURL, fixture.repo, fixture.tag, "opencode-config-bundle-"+fixture.tag+"-checksums.txt"),
 	)
+}
+
+func buildReleasesJSON(fixture githubReleaseServerFixture) string {
+	releases := fixture.releases
+	if len(releases) == 0 {
+		releases = []githubReleaseFixture{{Tag: fixture.tag}}
+	}
+
+	parts := make([]string, 0, len(releases))
+	for _, release := range releases {
+		archiveName := fmt.Sprintf("opencode-config-bundle-%s.tar.gz", release.Tag)
+		assetJSON := fmt.Sprintf(`[{"name":%q,"browser_download_url":%q}]`, archiveName, fmt.Sprintf("http://example.invalid/downloads/%s/releases/download/%s/%s", fixture.repo, release.Tag, archiveName))
+		parts = append(parts, fmt.Sprintf(`{"tag_name":%q,"prerelease":%t,"assets":%s}`, release.Tag, release.Prerelease, assetJSON))
+	}
+	return "[" + strings.Join(parts, ",") + "]"
 }


### PR DESCRIPTION
## Summary
- enumerate GitHub bundle releases instead of relying only on the stable `releases/latest` endpoint
- support interactive GitHub version selection in TTY mode, including prereleases, while keeping `--version latest` for latest stable
- surface clearer non-interactive errors for prerelease-only repositories and add regression tests around version selection and resolution

## Testing
- `go test ./...`

## Issues
- closes #145

## Traceability
- Primary story: US-035
- Related: US-038, US-039