### PR TITLE
feat: interactive bundle and preset selection flow

### DIFF
--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -48,22 +48,35 @@ Examples:
 
 // bundleApplyCmd applies a preset from a registered config bundle
 var bundleApplyCmd = &cobra.Command{
-	Use:   "apply <source-ref>",
+	Use:   "apply [source-ref]",
 	Short: "Apply a preset from a config bundle",
 	Long: `Apply a preset from a registered config bundle to a project.
 
 The source-ref may be either a registered source ID or a unique source name.
-In interactive terminals, omitting --preset opens a guided preset selection flow.
+When omitted in interactive mode, the command prompts for source and preset selection.
 
 Examples:
 	  oc bundle apply qbic --preset default
 	  oc bundle apply qbic
 	  oc bundle apply abc12345 --version v1.2.3 --preset default
 	  oc bundle apply qbic --preset minimal --project-root ./myproject
-	  oc bundle apply qbic --auto --preset default --force`,
-	Args: cobra.ExactArgs(1),
+	  oc bundle apply qbic --auto --preset default --force
+	  oc bundle apply (interactive mode)`,
+	Args: cobra.RangeArgs(0, 1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runBundleApply(args[0])
+		if len(args) > 0 {
+			return runBundleApply(args[0], false)
+		}
+		// No arguments provided - enter interactive mode
+		if !bundleInputIsTTY() || bundleAuto {
+			return fmt.Errorf("source-ref is required in non-interactive mode or when using --auto flag")
+		}
+		// Interactive source and preset selection
+		sourceRef, err := promptForSourceSelection()
+		if err != nil {
+			return err
+		}
+		return runBundleApply(sourceRef, true)
 	},
 }
 
@@ -113,7 +126,7 @@ func init() {
 	bundleApplyCmd.Flags().StringVar(&bundleVersion, "version", "", "Bundle version/tag to apply for github-release sources")
 	bundleApplyCmd.Flags().StringVar(&bundleProjectRoot, "project-root", ".", "Project root directory")
 	bundleApplyCmd.Flags().StringVar(&bundleOutput, "output", "opencode.json", "Output file path")
-	bundleApplyCmd.Flags().BoolVar(&bundleAuto, "auto", false, "Disable interactive preset selection")
+	bundleApplyCmd.Flags().BoolVar(&bundleAuto, "auto", false, "Run in non-interactive mode (requires source-ref and --preset)")
 	bundleApplyCmd.Flags().BoolVar(&bundleForce, "force", false, "Overwrite existing files")
 	bundleApplyCmd.Flags().BoolVar(&bundleDryRun, "dry-run", false, "Show what would be done without doing it")
 	bundleApplyCmd.ValidArgsFunction = completeSourceRefs
@@ -127,7 +140,7 @@ func init() {
 	bundleUpdateCmd.Flags().BoolVar(&bundleYes, "yes", false, "Skip confirmation prompt")
 }
 
-func runBundleApply(sourceRef string) error {
+func runBundleApply(sourceRef string, interactivePreset bool) error {
 	// Resolve project root
 	projectRoot, err := filepath.Abs(bundleProjectRoot)
 	if err != nil {
@@ -171,7 +184,7 @@ func runBundleApply(sourceRef string) error {
 
 	selectedPreset := bundlePreset
 	if selectedPreset == "" {
-		if bundleAuto || !bundleInputIsTTY() {
+		if bundleAuto || (!interactivePreset && !bundleInputIsTTY()) {
 			return fmt.Errorf("--preset is required outside interactive mode")
 		}
 		selectedPreset, err = promptForPresetSelection(manifest)
@@ -330,6 +343,59 @@ func promptForPresetSelection(manifest *bundle.Manifest) (string, error) {
 		}
 
 		fmt.Fprintln(bundlePromptOut, "Invalid selection. Please enter a preset number or exact name.")
+	}
+}
+
+func promptForSourceSelection() (string, error) {
+	sources, err := source.ListSources()
+	if err != nil {
+		return "", fmt.Errorf("failed to list sources: %w", err)
+	}
+
+	if len(sources) == 0 {
+		return "", fmt.Errorf("no sources registered (run 'oc bundle source add <location>' to register a source)")
+	}
+
+	reader := bufio.NewReader(bundlePromptIn)
+	for {
+		fmt.Fprintln(bundlePromptOut, "Available sources:")
+		for i, src := range sources {
+			fmt.Fprintf(bundlePromptOut, "  %d) %s (%s) - %s\n", i+1, src.ID, src.Type, src.Name)
+		}
+		fmt.Fprint(bundlePromptOut, "Select a source: ")
+
+		selection, err := reader.ReadString('\n')
+		if err != nil {
+			if err == io.EOF {
+				return "", fmt.Errorf("interactive source selection cancelled")
+			}
+			return "", fmt.Errorf("failed to read source selection: %w", err)
+		}
+
+		selection = strings.TrimSpace(selection)
+
+		// First check for exact name match
+		for _, src := range sources {
+			if src.Name == selection {
+				return src.ID, nil
+			}
+		}
+
+		// Then check for exact ID match
+		for _, src := range sources {
+			if src.ID == selection {
+				return src.ID, nil
+			}
+		}
+
+		// Finally check for index
+		if index, err := strconv.Atoi(selection); err == nil {
+			if index >= 1 && index <= len(sources) {
+				return sources[index-1].ID, nil
+			}
+		}
+
+		fmt.Fprintln(bundlePromptOut, "Invalid selection. Please enter a source number, ID, or name.")
 	}
 }
 

--- a/cmd/bundle_test.go
+++ b/cmd/bundle_test.go
@@ -53,7 +53,7 @@ func TestBundleApplyNoSource(t *testing.T) {
 	bundleProjectRoot = "."
 	bundleDryRun = false
 
-	err := runBundleApply("nonexistent-id")
+	err := runBundleApply("nonexistent-id", false)
 	if err == nil {
 		t.Error("runBundleApply() expected error for nonexistent source")
 	}
@@ -95,7 +95,7 @@ func TestBundleApplyMissingPreset(t *testing.T) {
 	bundleInputIsTTY = func() bool { return false }
 	bundleProjectRoot = t.TempDir()
 
-	err := runBundleApply("abc12345")
+	err := runBundleApply("abc12345", false)
 	if err == nil {
 		t.Error("runBundleApply() expected error when preset is missing")
 	}
@@ -219,7 +219,7 @@ func TestBundleApplyPassesVersionForGitHubSources(t *testing.T) {
 		return bundleRoot, func() {}, nil
 	}
 
-	if err := runBundleApply("github1"); err != nil {
+	if err := runBundleApply("github1", false); err != nil {
 		t.Fatalf("runBundleApply() error = %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(projectRoot, "opencode.json")); err != nil {
@@ -291,7 +291,7 @@ func TestBundleApplyInteractiveSelectsGitHubReleaseVersion(t *testing.T) {
 		return bundleRoot, func() {}, nil
 	}
 
-	if err := runBundleApply("github1"); err != nil {
+	if err := runBundleApply("github1", false); err != nil {
 		t.Fatalf("runBundleApply() error = %v", err)
 	}
 }
@@ -329,7 +329,7 @@ func TestBundleApplyGitHubSourceRequiresVersionOutsideInteractiveMode(t *testing
 		return []bundle.GitHubReleaseVersion{{TagName: "v1.3.0", Prerelease: false}, {TagName: "v1.4.0-alpha.1", Prerelease: true}}, nil
 	}
 
-	err := runBundleApply("github1")
+	err := runBundleApply("github1", false)
 	if err == nil {
 		t.Fatal("runBundleApply() error = nil, want version-selection error")
 	}
@@ -371,7 +371,7 @@ func TestBundleApplyGitHubSourceReportsPrereleaseOnlyOutsideInteractiveMode(t *t
 		return []bundle.GitHubReleaseVersion{{TagName: "v1.4.0-alpha.1", Prerelease: true}, {TagName: "v1.3.0-alpha.2", Prerelease: true}}, nil
 	}
 
-	err := runBundleApply("github1")
+	err := runBundleApply("github1", false)
 	if err == nil {
 		t.Fatal("runBundleApply() error = nil, want prerelease-only version-selection error")
 	}
@@ -413,7 +413,7 @@ func TestBundleApplyGitHubSourceSinglePrereleaseStillRequiresVersionOutsideInter
 		return []bundle.GitHubReleaseVersion{{TagName: "v1.4.0-alpha.1", Prerelease: true}}, nil
 	}
 
-	err := runBundleApply("github1")
+	err := runBundleApply("github1", false)
 	if err == nil {
 		t.Fatal("runBundleApply() error = nil, want prerelease-only version-selection error")
 	}
@@ -557,7 +557,7 @@ func TestBundleApplyRejectsVersionForLocalSources(t *testing.T) {
 	bundleProjectRoot = projectRoot
 	bundleVersion = "v1.2.3"
 
-	err := runBundleApply("local1")
+	err := runBundleApply("local1", false)
 	if err == nil {
 		t.Fatal("runBundleApply() error = nil, want error")
 	}
@@ -603,7 +603,7 @@ func TestBundleApplyResolvesSourceByName(t *testing.T) {
 	bundlePreset = "test"
 	bundleProjectRoot = projectRoot
 
-	if err := runBundleApply("qbic"); err != nil {
+	if err := runBundleApply("qbic", false); err != nil {
 		t.Fatalf("runBundleApply() error = %v", err)
 	}
 
@@ -630,7 +630,7 @@ func TestBundleApplyRejectsAmbiguousSourceName(t *testing.T) {
 	bundlePreset = "test"
 	defer func() { bundlePreset = origPreset }()
 
-	err := runBundleApply("qbic")
+	err := runBundleApply("qbic", false)
 	if err == nil {
 		t.Fatal("runBundleApply() error = nil, want ambiguous source error")
 	}
@@ -684,7 +684,7 @@ func TestBundleApplyInteractiveSelectsPreset(t *testing.T) {
 	bundlePromptIn = strings.NewReader("2\n")
 	bundlePromptOut = io.Discard
 
-	if err := runBundleApply("qbic"); err != nil {
+	if err := runBundleApply("qbic", false); err != nil {
 		t.Fatalf("runBundleApply() error = %v", err)
 	}
 

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -274,6 +274,48 @@ func TestBundleApplyRequiresPresetOutsideTTY(t *testing.T) {
 	requireContains(t, applyResult.stderr, "--preset is required outside interactive mode")
 }
 
+func TestBundleApplyNoArgsFailsInNonTTY(t *testing.T) {
+	// When run without arguments in non-TTY (e2e tests), should fail with helpful message
+	// Use empty stdin to ensure no TTY is detected
+	projectRoot := t.TempDir()
+	result := runOCWithStdin(t, testEnv(t), strings.NewReader(""), "bundle", "apply", "--project-root", projectRoot)
+	requireFailure(t, result)
+	// When there are no sources, it should fail with "no sources registered"
+	// OR when there are sources but no TTY, fail with "source-ref is required"
+	requireContains(t, result.stderr, "source-ref is required")
+	requireContains(t, result.stderr, "non-interactive mode")
+}
+
+func TestBundleApplyAutoFlagRequiresSourceRef(t *testing.T) {
+	// --auto flag should require source-ref argument regardless of TTY
+	env := testEnv(t)
+	bundleDir := copyFixtureBundle(t)
+
+	addResult := runOC(t, env, "source", "add", bundleDir, "--name", "fixture-dir")
+	requireSuccess(t, addResult)
+
+	projectRoot := t.TempDir()
+	// Using --auto without source-ref should fail
+	result := runOCWithStdin(t, env, strings.NewReader(""), "bundle", "apply", "--auto", "--project-root", projectRoot)
+	requireFailure(t, result)
+	requireContains(t, result.stderr, "source-ref is required")
+	requireContains(t, result.stderr, "--auto")
+}
+
+func TestBundleApplyAutoFlagWithPresetRequiresSource(t *testing.T) {
+	// --auto with --preset but no source-ref should fail
+	env := testEnv(t)
+	bundleDir := copyFixtureBundle(t)
+
+	addResult := runOC(t, env, "source", "add", bundleDir, "--name", "fixture-dir")
+	requireSuccess(t, addResult)
+
+	projectRoot := t.TempDir()
+	result := runOCWithStdin(t, env, strings.NewReader(""), "bundle", "apply", "--auto", "--preset", "fixture", "--project-root", projectRoot)
+	requireFailure(t, result)
+	requireContains(t, result.stderr, "source-ref is required")
+}
+
 func TestSourceAddFailsWithoutManifest(t *testing.T) {
 	bundleDir := t.TempDir()
 	result := runOC(t, testEnv(t), "source", "add", bundleDir)


### PR DESCRIPTION
## Summary

- Support `oc bundle apply` without arguments in TTY mode
- Add interactive source selection prompt (first selects source, then preset)
- Add `--auto` flag handling for non-interactive mode
- Add 3 new E2E tests for the new scenarios
- Maintain backward compatibility with existing usage

## New Flow

```bash
# Interactive (TTY) - new behavior
oc bundle apply           # → prompts for source → prompts for preset → applies

# Non-interactive (non-TTY) - new behavior  
oc bundle apply           # → error: source-ref is required
oc bundle apply --auto    # → error: source-ref is required

# Existing - unchanged
oc bundle apply <source> --preset <name>  # ✅ works as before
```

## Verification

- `go test ./cmd/... ./internal/...` - all pass
- `OC_E2E_BINARY=./opencode-test go test ./e2e/...` - all pass (16 tests)

Implements: US-050