### PR TITLE
docs: add shell completion installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,13 @@ oc completion bash | sudo tee /etc/bash_completion.d/oc > /dev/null
 
 # Zsh: source on the fly (recommended)
 source <(oc completion zsh)
+# If you use alias (alias oc="opencode-config-cli"), also add:
+compdef _oc opencode-config-cli
 
 # Or save to completions dir:
 # oc completion zsh > ~/.zsh/completions/_oc
 # Add to ~/.zshrc: fpath=(~/.zsh/completions $fpath)
+# Add: compdef _oc opencode-config-cli
 # Clear cache: rm -f ~/.zcompdump && exec zsh
 
 # Fish

--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ oc completion bash | sudo tee /etc/bash_completion.d/oc > /dev/null
 # Zsh: source on the fly (recommended)
 source <(oc completion zsh)
 
-# Or save to completions dir (may require sourcing after compinit):
+# Or save to completions dir:
 # oc completion zsh > ~/.zsh/completions/_oc
 # Add to ~/.zshrc: fpath=(~/.zsh/completions $fpath)
-# Clear cache and restart: rm -f ~/.zcompdump && exec zsh
+# Clear cache: rm -f ~/.zcompdump && exec zsh
 
 # Fish
 oc completion fish > ~/.config/fish/completions/oc.fish

--- a/README.md
+++ b/README.md
@@ -36,6 +36,29 @@ Install methods:
 - `go install` (recommended)
 - Manual download from GitHub Releases
 
+## Shell Completion
+
+Enable tab completion for your shell:
+
+```sh
+# Bash: source on the fly, or install permanently
+source <(oc completion bash)
+oc completion bash | sudo tee /etc/bash_completion.d/oc > /dev/null
+
+# Zsh: source on the fly (recommended)
+source <(oc completion zsh)
+
+# Or save to completions dir (may require sourcing after compinit):
+# oc completion zsh > ~/.zsh/completions/_oc
+# Add to ~/.zshrc: fpath=(~/.zsh/completions $fpath)
+# Clear cache and restart: rm -f ~/.zcompdump && exec zsh
+
+# Fish
+oc completion fish > ~/.config/fish/completions/oc.fish
+```
+
+Run `oc completion --help` for full instructions.
+
 ## Key Concepts
 
 | Concept | Description |

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -13,32 +13,33 @@ var completionCmd = &cobra.Command{
 	Long: `Generate shell completion scripts for supported shells.
 
 Bash:
-  # Source completion in your shell
+  # Source on the fly
   source <(oc completion bash)
 
-  # Or install permanently (requires sudo for /etc, or use ~/.local/):
+  # Or install permanently
   oc completion bash | sudo tee /etc/bash_completion.d/oc > /dev/null
 
 Zsh:
-  # Save completion file
-  oc completion zsh > ~/.zsh/completions/_oc
-
-  # Add to ~/.zshrc (MUST be after compinit):
-  # Note: The completion file requires compinit to be loaded first.
-  # If you see "compdef: command not found", source completion after compinit.
-  # Example: source <(oc completion zsh)
-
-  # Alternative: source on the fly (works automatically)
+  # Option 1: Source on the fly (recommended)
+  # Add to end of ~/.zshrc:
   source <(oc completion zsh)
+
+  # Option 2: Save to completions dir
+  oc completion zsh > ~/.zsh/completions/_oc
+  # Ensure ~/.zshrc has: fpath=(~/.zsh/completions $fpath)
 
   # Clear completion cache and restart:
   rm -f ~/.zcompdump && exec zsh
+
+  # Note: If you get "parse error" when pressing TAB, try:
+  # 1. Ensure you're using the binary name (oc), not an alias
+  # 2. Or add explicit completion binding after sourcing:
+  #    compdef _oc oc
 
 Fish:
   oc completion fish > ~/.config/fish/completions/oc.fish
 
 PowerShell:
-  # Add to your PowerShell profile
   oc completion powershell >> $PROFILE
 
 For more details, see: https://github.com/sven1103-agent/opencode-config-cli#shell-completion

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -21,20 +21,18 @@ Bash:
 
 Zsh:
   # Option 1: Source on the fly (recommended)
-  # Add to end of ~/.zshrc:
+  # Add to end of ~/.zshrc (after compinit):
   source <(oc completion zsh)
+  # If you use alias (alias oc="opencode-config-cli"), also run:
+  compdef _oc opencode-config-cli
 
   # Option 2: Save to completions dir
   oc completion zsh > ~/.zsh/completions/_oc
   # Ensure ~/.zshrc has: fpath=(~/.zsh/completions $fpath)
+  # Then add: compdef _oc opencode-config-cli
 
   # Clear completion cache and restart:
   rm -f ~/.zcompdump && exec zsh
-
-  # Note: If you get "parse error" when pressing TAB, try:
-  # 1. Ensure you're using the binary name (oc), not an alias
-  # 2. Or add explicit completion binding after sourcing:
-  #    compdef _oc oc
 
 Fish:
   oc completion fish > ~/.config/fish/completions/oc.fish

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -8,9 +8,41 @@ import (
 )
 
 var completionCmd = &cobra.Command{
-	Use:       "completion [bash|zsh|fish|powershell]",
-	Short:     "Generate shell completions",
-	Long:      "Generate shell completion scripts for supported shells.",
+	Use:   "completion [bash|zsh|fish|powershell]",
+	Short: "Generate shell completions",
+	Long: `Generate shell completion scripts for supported shells.
+
+Bash:
+  # Source completion in your shell
+  source <(oc completion bash)
+
+  # Or install permanently (requires sudo for /etc, or use ~/.local/):
+  oc completion bash | sudo tee /etc/bash_completion.d/oc > /dev/null
+
+Zsh:
+  # Save completion file
+  oc completion zsh > ~/.zsh/completions/_oc
+
+  # Add to ~/.zshrc (MUST be after compinit):
+  # Note: The completion file requires compinit to be loaded first.
+  # If you see "compdef: command not found", source completion after compinit.
+  # Example: source <(oc completion zsh)
+
+  # Alternative: source on the fly (works automatically)
+  source <(oc completion zsh)
+
+  # Clear completion cache and restart:
+  rm -f ~/.zcompdump && exec zsh
+
+Fish:
+  oc completion fish > ~/.config/fish/completions/oc.fish
+
+PowerShell:
+  # Add to your PowerShell profile
+  oc completion powershell >> $PROFILE
+
+For more details, see: https://github.com/sven1103-agent/opencode-config-cli#shell-completion
+`,
 	Args:      cobra.ExactArgs(1),
 	ValidArgs: []string{"bash", "zsh", "fish", "powershell"},
 	RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Summary

- Add detailed shell completion installation instructions to `oc completion --help` output
- Add Shell Completion section to README.md with quick setup examples

Fixes #78