### PR TITLE
chore: bump version to v1.0.0-alpha.8

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -4,4 +4,4 @@ package version
 // Version is the current version of oc.
 // Release automation updates this in the tagged source so `go install
 // module@version` reports the same version as release binaries.
-var Version = "v1.0.0-alpha.7"
+var Version = "v1.0.0-alpha.8"


### PR DESCRIPTION
## Summary
- Bump CLI tool version from v1.0.0-alpha.7 to v1.0.0-alpha.8