### PR TITLE
fix: use hash-based source IDs from normalized location

### DIFF
--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -2,6 +2,8 @@
 package source
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -11,8 +13,6 @@ import (
 	"sort"
 	"strings"
 	"time"
-
-	"github.com/google/uuid"
 )
 
 // SourceType represents the type of a config source.
@@ -365,6 +365,39 @@ func ValidateSource(location string, sourceType SourceType) error {
 	return nil
 }
 
+func normalizeLocation(location string, sourceType SourceType) string {
+	switch sourceType {
+	case SourceTypeGitHubRelease:
+		ref, err := parseGitHubRef(location)
+		if err != nil {
+			return location
+		}
+		return strings.ToLower(ref.Repo)
+	case SourceTypeLocalDirectory:
+		clean := filepath.Clean(location)
+		if strings.HasPrefix(clean, "~/") {
+			home, err := os.UserHomeDir()
+			if err == nil {
+				clean = filepath.Join(home, strings.TrimPrefix(clean, "~/"))
+			}
+		}
+		abs, err := filepath.Abs(clean)
+		if err != nil {
+			return clean
+		}
+		return abs
+	case SourceTypeLocalArchive:
+		return filepath.Clean(location)
+	default:
+		return location
+	}
+}
+
+func generateSourceID(normalizedLocation string) string {
+	hash := sha256.Sum256([]byte(normalizedLocation))
+	return hex.EncodeToString(hash[:])[:8]
+}
+
 // AddSource adds a new source to the registry.
 func AddSource(location string, name string) (*Source, error) {
 	// Detect source type
@@ -384,15 +417,18 @@ func AddSource(location string, name string) (*Source, error) {
 		return nil, err
 	}
 
-	// Check for duplicate locations
+	// Normalize location for consistent ID generation and duplicate check
+	normalizedLocation := normalizeLocation(location, sourceType)
+
+	// Check for duplicate locations (compare normalized)
 	for _, s := range registry.Sources {
-		if s.Location == location {
+		if normalizeLocation(s.Location, s.Type) == normalizedLocation {
 			return nil, fmt.Errorf("source already registered at location: %s (id: %s)", location, s.ID)
 		}
 	}
 
-	// Generate ID if name not provided
-	id := uuid.New().String()[:8]
+	// Generate ID from normalized location
+	id := generateSourceID(normalizedLocation)
 	if name == "" {
 		if sourceType == SourceTypeGitHubRelease {
 			ref, err := parseGitHubRef(location)


### PR DESCRIPTION
## Summary

Replace random UUID-based ID generation with deterministic hash-based IDs derived from normalized source location.

## Problem

When a user adds a bundle from an installed source, removes the source, and then re-adds the same source, the bundle becomes orphaned. This happens because:
- Source IDs were randomly generated (`uuid.New().String()[:8]`)
- When a source is removed and re-added, it gets a **new random ID**
- The project's `.opencode/bundle-provenance.json` stores the old `SourceID`
- Bundle operations fail because the old SourceID no longer exists in the registry

## Solution

1. **Add `normalizeLocation()` function** that normalizes source locations:
   - GitHub: lowercase `owner/repo` 
   - Local: `filepath.Clean()`, expand `~/`, resolve to absolute path

2. **Add `generateSourceID()` function** that generates IDs from normalized location using SHA256 hash

3. **Update `AddSource()`** to use hash-based ID and normalized duplicate check

This ensures re-adding a source with the same location produces the same ID, keeping previously applied bundles functional.

## Testing

All existing tests pass.

---

Fixes #169