### PR TITLE
chore: rename repository from opencode-config-cli to occo

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Releases
-    url: https://github.com/sven1103-agent/opencode-config-cli/releases
+    url: https://github.com/qbicsoftware/occo/releases
     about: Try the latest prerelease and report issues here

--- a/.github/workflows/e2e-cli.yml
+++ b/.github/workflows/e2e-cli.yml
@@ -36,9 +36,9 @@ jobs:
         run: mkdir -p .tmp
 
       - name: Build CLI
-        run: go build -o .tmp/oc .
+        run: go build -o .tmp/occo .
 
       - name: Run E2E tests
         run: go test ./e2e -v
         env:
-          OC_E2E_BINARY: ${{ github.workspace }}/.tmp/oc
+          OC_E2E_BINARY: ${{ github.workspace }}/.tmp/occo

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,18 +1,18 @@
 # .goreleaser.yaml
-# GoReleaser configuration for opencode-helper
+# GoReleaser configuration for occo
 # https://goreleaser.com/introduction
 
 version: 2
 
-project_name: oc
+project_name: occo
 
 before:
   hooks:
     - go mod tidy
 
 builds:
-  - id: oc
-    binary: oc
+  - id: occo
+    binary: occo
     main: ./main.go
     env:
       - CGO_ENABLED=0
@@ -28,15 +28,15 @@ builds:
         goarch: arm64
     ldflags:
       - -s -w
-      - -X github.com/sven1103-agent/opencode-config-cli/internal/version.Version={{.Version}}
+      - -X github.com/qbicsoftware/occo/internal/version.Version={{.Version}}
 
 changelog:
   disable: true
 
 release:
   github:
-    owner: sven1103-agent
-    name: opencode-config-cli
+    owner: qbicsoftware
+    name: occo
   draft: false
   prerelease: auto
   name_template: "{{.Tag}}"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# OpenCode Config CLI
+# Occo
 
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE)
-[![Go Version](https://img.shields.io/github/go-mod/go-version/sven1103-agent/opencode-config-cli?logo=go)](https://github.com/sven1103-agent/opencode-config-cli/blob/main/go.mod)
-[![Version](https://img.shields.io/github/v/release/sven1103-agent/opencode-config-cli?include_prereleases&label=version)](https://github.com/sven1103-agent/opencode-config-cli/releases)
-[![CI](https://github.com/sven1103-agent/opencode-config-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/sven1103-agent/opencode-config-cli/actions/workflows/ci.yml)
-[![E2E CLI](https://github.com/sven1103-agent/opencode-config-cli/actions/workflows/e2e-cli.yml/badge.svg)](https://github.com/sven1103-agent/opencode-config-cli/actions/workflows/e2e-cli.yml)
+[![Go Version](https://img.shields.io/github/go-mod/go-version/qbicsoftware/occo?logo=go)](https://github.com/qbicsoftware/occo/blob/main/go.mod)
+[![Version](https://img.shields.io/github/v/release/qbicsoftware/occo?include_prereleases&label=version)](https://github.com/qbicsoftware/occo/releases)
+[![CI](https://github.com/qbicsoftware/occo/actions/workflows/ci.yml/badge.svg)](https://github.com/qbicsoftware/occo/actions/workflows/ci.yml)
+[![E2E CLI](https://github.com/qbicsoftware/occo/actions/workflows/e2e-cli.yml/badge.svg)](https://github.com/qbicsoftware/occo/actions/workflows/e2e-cli.yml)
 
 **Manage OpenCode configuration bundles and schema-validated multi-agent workflows**
 
@@ -17,22 +17,19 @@ Repeatable capture steps: [docs/demo-playbook.md](docs/demo-playbook.md)
 
 ## What is this?
 
-A CLI tool (`oc`) that manages OpenCode [configuration bundles](docs/config-bundles.md) from external sources, enabling versioned, validated configs for AI agents.
+A CLI tool (`occo`) that manages OpenCode [configuration bundles](docs/config-bundles.md) from external sources, enabling versioned, validated configs for AI agents.
 
 ## Quick Start (30 seconds)
 
 ```sh
 # Install via Go (macOS/Linux)
-go install github.com/sven1103-agent/opencode-config-cli@latest
-
-# Create an alias to the default installation location
-alias oc='$HOME/go/bin/opencode-config-cli'
+go install github.com/qbicsoftware/occo@latest
 
 # Register a config bundle
-oc source add qbicsoftware/opencode-config-bundle --name qbic
+occo source add qbicsoftware/opencode-config-bundle --name qbic
 
 # Install a preset
-oc bundle install qbic --preset mixed --project-root .
+occo bundle install qbic --preset mixed --project-root .
 ```
 
 ## Installation
@@ -49,25 +46,22 @@ Enable tab completion for your shell:
 
 ```sh
 # Bash: source on the fly, or install permanently
-source <(oc completion bash)
-oc completion bash | sudo tee /etc/bash_completion.d/oc > /dev/null
+source <(occo completion bash)
+occo completion bash | sudo tee /etc/bash_completion.d/occo > /dev/null
 
 # Zsh: source on the fly (recommended)
-source <(oc completion zsh)
-# If you use alias (alias oc="opencode-config-cli"), also add:
-compdef _oc opencode-config-cli
+source <(occo completion zsh)
 
 # Or save to completions dir:
-# oc completion zsh > ~/.zsh/completions/_oc
+# occo completion zsh > ~/.zsh/completions/_occo
 # Add to ~/.zshrc: fpath=(~/.zsh/completions $fpath)
-# Add: compdef _oc opencode-config-cli
 # Clear cache: rm -f ~/.zcompdump && exec zsh
 
 # Fish
-oc completion fish > ~/.config/fish/completions/oc.fish
+occo completion fish > ~/.config/fish/completions/occo.fish
 ```
 
-Run `oc completion --help` for full instructions.
+Run `occo completion --help` for full instructions.
 
 ## Key Concepts
 
@@ -94,7 +88,7 @@ Run `oc completion --help` for full instructions.
 
 ## Legacy (Bash Version)
 
-The original Bash-based helper is deprecated. Use the Go CLI (`oc`) instead.
+The original Bash-based helper is deprecated. Use the Go CLI (`occo`) instead.
 
 Archive documentation: [docs/legacy/bash-helper.md](docs/legacy/bash-helper.md)
 

--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -11,10 +11,10 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/qbicsoftware/occo/internal/bundle"
+	configpreset "github.com/qbicsoftware/occo/internal/preset"
+	"github.com/qbicsoftware/occo/internal/source"
 	"github.com/spf13/cobra"
-	"github.com/sven1103-agent/opencode-config-cli/internal/bundle"
-	configpreset "github.com/sven1103-agent/opencode-config-cli/internal/preset"
-	"github.com/sven1103-agent/opencode-config-cli/internal/source"
 )
 
 var (

--- a/cmd/bundle_test.go
+++ b/cmd/bundle_test.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/qbicsoftware/occo/internal/bundle"
+	"github.com/qbicsoftware/occo/internal/source"
 	"github.com/spf13/cobra"
-	"github.com/sven1103-agent/opencode-config-cli/internal/bundle"
-	"github.com/sven1103-agent/opencode-config-cli/internal/source"
 )
 
 // setupTestProject creates a temporary project directory

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -14,33 +14,29 @@ var completionCmd = &cobra.Command{
 
 Bash:
   # Source on the fly
-  source <(oc completion bash)
+  source <(occo completion bash)
 
   # Or install permanently
-  oc completion bash | sudo tee /etc/bash_completion.d/oc > /dev/null
+  occo completion bash | sudo tee /etc/bash_completion.d/occo > /dev/null
 
 Zsh:
   # Option 1: Source on the fly (recommended)
   # Add to end of ~/.zshrc (after compinit):
-  source <(oc completion zsh)
-  # If you use alias (alias oc="opencode-config-cli"), also run:
-  compdef _oc opencode-config-cli
+  source <(occo completion zsh)
 
   # Option 2: Save to completions dir
-  oc completion zsh > ~/.zsh/completions/_oc
+  occo completion zsh > ~/.zsh/completions/_occo
   # Ensure ~/.zshrc has: fpath=(~/.zsh/completions $fpath)
-  # Then add: compdef _oc opencode-config-cli
-
   # Clear completion cache and restart:
   rm -f ~/.zcompdump && exec zsh
 
 Fish:
-  oc completion fish > ~/.config/fish/completions/oc.fish
+  occo completion fish > ~/.config/fish/completions/occo.fish
 
 PowerShell:
-  oc completion powershell >> $PROFILE
+  occo completion powershell >> $PROFILE
 
-For more details, see: https://github.com/sven1103-agent/opencode-config-cli#shell-completion
+For more details, see: https://github.com/qbicsoftware/occo#shell-completion
 `,
 	Args:      cobra.ExactArgs(1),
 	ValidArgs: []string{"bash", "zsh", "fish", "powershell"},
@@ -54,12 +50,12 @@ For more details, see: https://github.com/sven1103-agent/opencode-config-cli#she
 			return rootCmd.GenFishCompletion(os.Stdout, true)
 		case "powershell":
 			return rootCmd.GenPowerShellCompletionWithDesc(os.Stdout)
-		default:
-			return fmt.Errorf("unsupported shell: %s", args[0])
 		}
+		return fmt.Errorf("unsupported shell: %s", args[0])
 	},
 }
 
 func init() {
+	completionCmd.Flags().BoolP("help", "h", false, "Help for completion")
 	rootCmd.AddCommand(completionCmd)
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -6,9 +6,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/qbicsoftware/occo/internal/preset"
+	"github.com/qbicsoftware/occo/internal/schema"
 	"github.com/spf13/cobra"
-	"github.com/sven1103-agent/opencode-config-cli/internal/preset"
-	"github.com/sven1103-agent/opencode-config-cli/internal/schema"
 )
 
 // validateOutputPath ensures the output path stays within the project root

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,22 +4,22 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/qbicsoftware/occo/internal/version"
 	"github.com/spf13/cobra"
-	"github.com/sven1103-agent/opencode-config-cli/internal/version"
 )
 
 var versionFlag bool
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "oc",
-	Short: "oc - OpenCode configuration manager",
-	Long: `oc is the OpenCode configuration manager CLI.
+	Use:   "occo",
+	Short: "occo - OpenCode configuration manager",
+	Long: `occo is the OpenCode configuration manager CLI.
 
 Manage OpenCode configurations, including presets, sources, and bundle operations.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if versionFlag {
-			fmt.Printf("oc %s\n", version.Version)
+			fmt.Printf("occo %s\n", version.Version)
 			os.Exit(0)
 		}
 		_ = cmd.Help()

--- a/cmd/source.go
+++ b/cmd/source.go
@@ -6,9 +6,9 @@ import (
 	"path/filepath"
 	"text/tabwriter"
 
+	"github.com/qbicsoftware/occo/internal/bundle"
+	"github.com/qbicsoftware/occo/internal/source"
 	"github.com/spf13/cobra"
-	"github.com/sven1103-agent/opencode-config-cli/internal/bundle"
-	"github.com/sven1103-agent/opencode-config-cli/internal/source"
 )
 
 var (

--- a/cmd/source_test.go
+++ b/cmd/source_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sven1103-agent/opencode-config-cli/internal/source"
+	"github.com/qbicsoftware/occo/internal/source"
 )
 
 // saveRegistry saves the current registry and returns a function to restore it

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -3,15 +3,15 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/qbicsoftware/occo/internal/version"
 	"github.com/spf13/cobra"
-	"github.com/sven1103-agent/opencode-config-cli/internal/version"
 )
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print version information",
-	Long:  `Print the version information for oc.`,
+	Long:  `Print the version information for occo.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("oc %s\n", version.Version)
+		fmt.Printf("occo %s\n", version.Version)
 	},
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
-# OpenCode Config CLI - Documentation
+# Occo - Documentation
 
-Welcome to the OpenCode Config CLI documentation. This CLI manages OpenCode configuration bundles from external sources, enabling versioned, validated configs for AI agents.
+Welcome to the Occo documentation. This CLI manages OpenCode configuration bundles from external sources, enabling versioned, validated configs for AI agents.
 
 ## Quick Links
 
@@ -23,16 +23,16 @@ Welcome to the OpenCode Config CLI documentation. This CLI manages OpenCode conf
 
 ```sh
 # Install via Go
-go install github.com/sven1103-agent/opencode-config-cli@latest
+go install github.com/qbicsoftware/occo@latest
 
 # Register a config bundle
-oc source add qbicsoftware/opencode-config-bundle --name qbic
+occo source add qbicsoftware/opencode-config-bundle --name qbic
 
 # Apply a preset
-oc bundle apply qbic --preset mixed --project-root .
+occo bundle apply qbic --preset mixed --project-root .
 
 # Or let the CLI prompt for a preset in a TTY
-oc bundle apply qbic --project-root .
+occo bundle apply qbic --project-root .
 ```
 
 ## Available Bundles
@@ -42,4 +42,4 @@ oc bundle apply qbic --project-root .
 ## Need Help?
 
 - Check the [troubleshooting guide](troubleshooting.md) for common issues
-- Open an issue at [github.com/sven1103-agent/opencode-config-cli/issues](https://github.com/sven1103-agent/opencode-config-cli/issues)
+- Open an issue at [github.com/qbicsoftware/occo/issues](https://github.com/qbicsoftware/occo/issues)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,6 +1,6 @@
 # CLI Reference
 
-Complete reference for the `oc` CLI commands.
+Complete reference for the `occo` CLI commands.
 
 ## Global Options
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-This guide covers how to install the OpenCode Config CLI (`oc`) on macOS and Linux.
+This guide covers how to install Occo on macOS and Linux.
 
 ## Prerequisites
 
@@ -15,28 +15,28 @@ This guide covers how to install the OpenCode Config CLI (`oc`) on macOS and Lin
 If you have Go installed:
 
 ```sh
-go install github.com/sven1103-agent/opencode-config-cli@latest
+go install github.com/qbicsoftware/occo@latest
 ```
 
-This installs the `oc` binary to `$GOPATH/bin` (or `$HOME/go/bin`). Make sure this directory is in your PATH.
+This installs the `occo` binary to `$GOPATH/bin` (or `$HOME/go/bin`). Make sure this directory is in your PATH.
 
 **Note:** `@latest` follows Go module version selection. It does not mean "latest GitHub prerelease".
 
 **Install a specific version:**
 
 ```sh
-go install github.com/sven1103-agent/opencode-config-cli@v1.0.0-alpha.6
+go install github.com/qbicsoftware/occo@v1.0.0
 ```
 
 ### Method 2: Manual Download
 
-Download the correct tarball for your platform from [GitHub Releases](https://github.com/sven1103-agent/opencode-config-cli/releases):
+Download the correct tarball for your platform from [GitHub Releases](https://github.com/qbicsoftware/occo/releases):
 
 ```sh
 # Example: macOS ARM64
-VERSION=v1.0.0-alpha.6
-curl -L "https://github.com/sven1103-agent/opencode-config-cli/releases/download/${VERSION}/oc_${VERSION#v}_darwin_arm64.tar.gz" | tar xz
-mv oc ~/.local/bin/
+VERSION=v1.0.0
+curl -L "https://github.com/qbicsoftware/occo/releases/download/${VERSION}/occo_${VERSION#v}_darwin_arm64.tar.gz" | tar xz
+mv occo ~/.local/bin/
 ```
 
 Set `VERSION` on its own line before running `curl`. Do not collapse this into `VERSION=... curl ...`, because `${VERSION}` is expanded by the shell before that temporary assignment takes effect.
@@ -58,14 +58,14 @@ To make this permanent, add the line above to your shell profile (`~/.zshrc` or 
 ## Verify Installation
 
 ```sh
-oc version
+occo version
 ```
 
-You should see output like `oc version 1.0.0-alpha.6`.
+You should see output like `occo version 1.0.0`.
 
 ## PATH Issues
 
-If you see "command not found: oc" after installation:
+If you see "command not found: occo" after installation:
 
 1. **For go install**: Ensure `$HOME/go/bin` is in your PATH
 2. **For manual download**: Ensure `~/.local/bin` is in your PATH
@@ -80,25 +80,48 @@ export PATH="$HOME/go/bin:$HOME/.local/bin:$PATH"
 Re-run `go install` with the desired version:
 
 ```sh
-go install github.com/sven1103-agent/opencode-config-cli@latest
+go install github.com/qbicsoftware/occo@latest
 ```
 
-Or download a new release manually from [GitHub Releases](https://github.com/sven1103-agent/opencode-config-cli/releases).
+Or download a new release manually from [GitHub Releases](https://github.com/qbicsoftware/occo/releases).
 
 ## Configuration Location
 
 The CLI stores registered sources in a JSON file. By default it follows the XDG Base Directory specification:
 
-- **Default location**: `~/.config/opencode-helper/sources.json`
+- **Default location**: `~/.config/occo/sources.json`
 - **Custom location**: Set `XDG_CONFIG_HOME` environment variable to override
 
 ### Legacy Migration
 
-If you used an older version of the CLI (pre-alpha.7), your sources may be in:
-- `~/.config/opencode-helper/config-sources.json` (shell script version)
+If you used an older version of the CLI (pre-v1.0.0), your sources may be in:
+- `~/.config/opencode-helper/sources.json` (shell script version)
 - `~/Library/Application Support/opencode-helper/sources.json` (pre-XDG Go CLI)
 
 These will be automatically migrated to the new XDG standard location on first run.
+
+## Shell Completion
+
+Enable tab completion for your shell:
+
+```sh
+# Bash: source on the fly, or install permanently
+source <(occo completion bash)
+occo completion bash | sudo tee /etc/bash_completion.d/occo > /dev/null
+
+# Zsh: source on the fly (recommended)
+source <(occo completion zsh)
+
+# Or save to completions dir:
+# occo completion zsh > ~/.zsh/completions/_occo
+# Add to ~/.zshrc: fpath=(~/.zsh/completions $fpath)
+# Clear cache: rm -f ~/.zcompdump && exec zsh
+
+# Fish
+occo completion fish > ~/.config/fish/completions/occo.fish
+```
+
+Run `occo completion --help` for full instructions.
 
 ## Next Steps
 

--- a/docs/specs/bundle-contract.md
+++ b/docs/specs/bundle-contract.md
@@ -1,10 +1,10 @@
 # Bundle Contract
 
-This document defines the contract that configuration bundles must comply with to work with the `oc` CLI.
+This document defines the contract that configuration bundles must comply with to work with the `occo` CLI.
 
 ## Ownership
 
-The bundle contract is **owned by the opencode-config-cli repository** where the CLI lives. All schema definitions, validation rules, and contract changes are managed here.
+The bundle contract is **owned by the occo repository** where the CLI lives. All schema definitions, validation rules, and contract changes are managed here.
 
 Configuration bundles (like [qbicsoftware/opencode-config-bundle](https://github.com/qbicsoftware/opencode-config-bundle)) are **consumers** of this contract.
 

--- a/docs/specs/opencode-helper-cli.md
+++ b/docs/specs/opencode-helper-cli.md
@@ -410,7 +410,7 @@ Depends on:
 The helper CLI shall publish a standalone bootstrap install script (`install.sh`) as a separate release asset alongside the release bundle, enabling the standard `curl|sh` one-liner distribution:
 
 ```sh
-curl -fsSL https://github.com/sven1103-agent/opencode-config-cli/releases/latest/download/install.sh | sh
+curl -fsSL https://github.com/qbicsoftware/occo/releases/latest/download/install.sh | sh
 ```
 
 The bootstrap script shall:
@@ -1445,8 +1445,8 @@ Status:
 - In review
 
 PR:
-- [#141](https://github.com/sven1103-agent/opencode-config-cli/pull/141)
-- [#142](https://github.com/sven1103-agent/opencode-config-cli/pull/142)
+- [#141](https://github.com/qbicsoftware/occo/pull/141)
+- [#142](https://github.com/qbicsoftware/occo/pull/142)
 
 Type:
 - User-facing
@@ -1513,7 +1513,7 @@ Story:
 
 Acceptance criteria:
 - Homebrew tap created/updated
-- Installation via `brew install sven1103-agent/opencode-config-cli/oc` works
+- Installation via `brew install qbicsoftware/occo/occo` works
 - Formula stays up to date with releases
 
 ---
@@ -1527,7 +1527,7 @@ Status:
 - Done
 
 PR:
-- [#120](https://github.com/sven1103-agent/opencode-config-cli/pull/120)
+- [#120](https://github.com/qbicsoftware/occo/pull/120)
 
 Type:
 - Release-engineering-facing
@@ -2357,7 +2357,7 @@ Story:
 - As a developer, I want to install `opencode-helper` with a single `curl|sh` command without cloning the repository, so that getting started with the helper CLI is frictionless.
 
 Acceptance criteria:
-- Given a macOS or Linux system with `curl` or `wget` available, when I run `curl -fsSL https://github.com/sven1103-agent/opencode-config-cli/releases/latest/download/install.sh | sh`, then `opencode-helper` is installed to `~/.local/bin/opencode-helper` and the helper is on `PATH`.
+- Given a macOS or Linux system with `curl` or `wget` available, when I run `curl -fsSL https://github.com/qbicsoftware/occo/releases/latest/download/install.sh | sh`, then `opencode-helper` is installed to `~/.local/bin/opencode-helper` and the helper is on `PATH`.
 - Given the bootstrap install script, when I run `curl .../install.sh | sh --version v1.0.0`, then the installed helper is from that exact release tag.
 - Given the bootstrap install script, when the downloaded `opencode-helper-install` fails its checksum verification, then the bootstrap exits non-zero without executing the installer.
 - Given `OPENCODE_HELPER_VERSION` is set in the environment, when the bootstrap runs, then it uses that tag instead of `latest`.

--- a/docs/specs/opencode-helper-v2-milestones.md
+++ b/docs/specs/opencode-helper-v2-milestones.md
@@ -68,7 +68,7 @@ This is the initial V2 baseline release with full config-source management suppo
 opencode-helper self-update
 
 # Or fresh install
-curl -fsSL https://github.com/sven1103-agent/opencode-config-cli/releases/latest/download/install.sh | sh
+curl -fsSL https://github.com/qbicsoftware/occo/releases/latest/download/install.sh | sh
 
 # For existing V1 projects, migration is optional
 opencode-helper migrate legacy-config --project-root ./myproject

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -88,7 +88,7 @@ Migration was aborted by user.
 
 If your issue isn't listed here:
 
-1. Check [existing issues](https://github.com/sven1103-agent/opencode-config-cli/issues)
+1. Check [existing issues](https://github.com/qbicsoftware/occo/issues)
 2. Open a new issue with:
    - CLI version (`oc version`)
    - OS and shell

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -42,7 +42,7 @@ type provenance struct {
 func TestVersion(t *testing.T) {
 	result := runOC(t, testEnv(t), "version")
 	requireSuccess(t, result)
-	if !strings.HasPrefix(result.stdout, "oc ") {
+	if !strings.HasPrefix(result.stdout, "occo ") {
 		t.Fatalf("expected version output, got stdout=%q stderr=%q", result.stdout, result.stderr)
 	}
 }

--- a/e2e/go_install_test.go
+++ b/e2e/go_install_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestGoInstallTaggedVersionReportsTag(t *testing.T) {
-	const modulePath = "github.com/sven1103-agent/opencode-config-cli"
+	const modulePath = "github.com/qbicsoftware/occo"
 	const moduleVersion = "v1.0.0-alpha.3"
 
 	proxyRoot := t.TempDir()
@@ -44,14 +44,14 @@ func TestGoInstallTaggedVersionReportsTag(t *testing.T) {
 	})
 	requireSuccess(t, install)
 
-	binaryPath := filepath.Join(binDir, "opencode-config-cli")
+	binaryPath := filepath.Join(binDir, "occo")
 	metadata := runCommand(t, commandSpec{name: "go", args: []string{"version", "-m", binaryPath}})
 	requireSuccess(t, metadata)
 	requireContains(t, metadata.stdout, modulePath+"\t"+moduleVersion)
 
 	version := runCommand(t, commandSpec{name: binaryPath, args: []string{"version"}})
 	requireSuccess(t, version)
-	requireContains(t, version.stdout, "oc "+moduleVersion)
+	requireContains(t, version.stdout, "occo "+moduleVersion)
 }
 
 type commandSpec struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/sven1103-agent/opencode-config-cli
+module github.com/qbicsoftware/occo
 
 go 1.21
 

--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -13,8 +13,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/qbicsoftware/occo/internal/source"
 	"github.com/santhosh-tekuri/jsonschema/v5"
-	"github.com/sven1103-agent/opencode-config-cli/internal/source"
 )
 
 //go:embed 1.0.0.schema.json

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/sven1103-agent/opencode-config-cli/cmd"
+	"github.com/qbicsoftware/occo/cmd"
 )
 
 func main() {


### PR DESCRIPTION
## Summary

- Renames the repository from `opencode-config-cli` to `occo`
- Changes the CLI binary name from `oc` to `occo`
- Updates all Go module paths, documentation, and tests

## Changes

- **go.mod**: Module path → `github.com/qbicsoftware/occo`
- **Binary name**: `oc` → `occo` (in `.goreleaser.yaml` and `cmd/root.go`)
- **Documentation**: Updated all references in README, installation guide, CLI reference, and specs
- **E2E tests**: Updated for new binary name

## Acceptance Criteria (from #163)

- [x] Repository renamed to `occo`
- [x] Go module path updated
- [x] Documentation reflects new name
- [x] Binary name changed to `occo`

Closes #163