### PR TITLE
fix: support prerelease-only bundles in source list --with-presets

### DIFF
--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -338,13 +338,21 @@ func inspectGitHubBundleVersion(sourceLocation, requestedVersion string) (string
 	if err != nil {
 		return "", err
 	}
+	var latestPrerelease string
 	for _, release := range releases {
 		if !release.Prerelease {
 			return release.TagName, nil
 		}
+		if latestPrerelease == "" || release.TagName > latestPrerelease {
+			latestPrerelease = release.TagName
+		}
 	}
 
-	return "", fmt.Errorf("no stable release found for %s; prereleases are available", ref.Repo)
+	if latestPrerelease != "" {
+		return latestPrerelease, nil
+	}
+
+	return "", fmt.Errorf("no releases found for %s", ref.Repo)
 }
 
 func promptForPresetSelection(manifest *bundle.Manifest) (string, error) {

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -716,7 +716,7 @@ func TestPresetListSourcesGitHubWithStableRelease(t *testing.T) {
 	requireContains(t, listResult.stdout, "fixture")
 }
 
-func TestPresetListSourcesGitHubPrereleaseOnlyWarns(t *testing.T) {
+func TestPresetListSourcesGitHubPrereleaseOnlySucceeds(t *testing.T) {
 	env := testEnv(t)
 	server := newGitHubReleaseE2EServer(t, githubReleaseE2EFixture{
 		repo: "owner/repo",
@@ -731,9 +731,10 @@ func TestPresetListSourcesGitHubPrereleaseOnlyWarns(t *testing.T) {
 	addResult := runOC(t, env, "source", "add", "owner/repo", "--name", "test-prerelease")
 	requireSuccess(t, addResult)
 
-	listResult := runOCWithStdin(t, env, strings.NewReader(""), "source", "list", "--with-presets")
-	requireFailure(t, listResult)
-	requireContains(t, listResult.stderr, "no stable release found")
+	listResult := runOC(t, env, "source", "list", "--with-presets")
+	requireSuccess(t, listResult)
+	requireContains(t, listResult.stdout, "v2.0.0-alpha.1")
+	requireContains(t, listResult.stdout, "fixture")
 }
 
 // Bundle Init E2E Tests for US-053


### PR DESCRIPTION
## Summary

- Fix `occo source list --with-presets` to support prerelease-only bundles by falling back to the latest prerelease when no stable release exists
- Aligns with bundle contract that states prereleases are valid bundle sources
- Updates E2E test to expect success instead of failure for prerelease-only bundles