### PR TITLE
[Documentation] Fix quickstart documentation (bundle install does not exist)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ go install github.com/qbicsoftware/occo@latest
 occo source add qbicsoftware/opencode-config-bundle --name qbic
 
 # Install a preset
-occo bundle install qbic --preset mixed --project-root .
+occo bundle apply qbic --preset mixed --project-root .
 ```
 
 ## Installation


### PR DESCRIPTION
The documentation mentions `occo bundle install` but the correct command is `occo bundle apply`. There is no `occo bundle install` command.

