### PR TITLE
[Documentation] Add hint for autocompletion setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ source <(occo completion zsh)
 
 # Or save to completions dir:
 # occo completion zsh > ~/.zsh/completions/_occo
-# Add to ~/.zshrc: fpath=(~/.zsh/completions $fpath)
-# Clear cache: rm -f ~/.zcompdump && exec zsh
+# Add to ~/.zshrc: fpath=(~/.zsh/completions $fpath); ensure fpath is set before `compinit`
+# (Optional) Clear cache: rm -f ~/.zcompdump && exec zsh
 
 # Fish
 occo completion fish > ~/.config/fish/completions/occo.fish


### PR DESCRIPTION
Adds a hint where to place the completion setup in the `.zshrc` file for `zsh` completion.