### PR TITLE
Add bug report issue template with version verification

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -1,0 +1,75 @@
+name: Bug Report
+description: Report something that isn't working as expected
+title: "[Bug] "
+labels: ["bug", "triage"]
+assignees: ""
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Run `opencode-helper version` and paste the output here
+      placeholder: e.g. v1.2.3
+    validations:
+      required: true
+  - type: checkboxes
+    id: latest
+    attributes:
+      label: Verification
+      description: Please ensure you're using the latest available version before reporting
+      options:
+        - label: I have verified this issue exists in the latest **available** version (check https://github.com/qbicsoftware/opencode-config-cli/releases)
+          required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      options:
+        - macOS
+        - Linux
+        - Windows
+        - Other (please specify in description)
+    validations:
+      required: true
+  - type: input
+    id: shell
+    attributes:
+      label: Shell
+      description: e.g. bash, zsh, PowerShell
+      placeholder: bash
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe what you expected to happen vs what actually happened
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Numbered list of steps to reproduce the issue
+      placeholder: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output (will be formatted as code)
+      render: shell
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Anything else that might be helpful (screenshots, related config, etc.)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Releases
     url: https://github.com/qbicsoftware/occo/releases


### PR DESCRIPTION
## Summary

- Add YAML-based GitHub issue form for bug reports (better UX than markdown)
- Require users to state CLI version and verify issue exists in latest available version
- Disable blank issues to ensure users always use a template

## Changes

- New `.github/ISSUE_TEMPLATE/1-bug-report.yml` with form fields:
  - Version input (with hint to run `opencode-helper version`)
  - Checkbox: "I have verified this issue exists in the latest **available** version"
  - OS dropdown + shell input
  - What happened / Steps to reproduce
  - Log output + additional context
- Updated `.github/ISSUE_TEMPLATE/config.yml` to disable blank issues