### PR TITLE
Fix invalid assignees property in bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -2,7 +2,6 @@ name: Bug Report
 description: Report something that isn't working as expected
 title: "[Bug] "
 labels: ["bug", "triage"]
-assignees: ""
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## Summary
- Remove invalid `assignees: ""` from bug report YAML template
- GitHub issue templates don't accept empty string for assignees; property must be either an array of usernames or omitted entirely