### PR TITLE
feat: add prompt file installation for bundle apply

### DIFF
--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -26,6 +26,7 @@ var (
 	bundleDryRun             bool
 	bundleOutput             string
 	bundleYes                bool
+	bundleInstallAssets                = true
 	bundleResolveToLocal               = bundle.ResolveToLocal
 	bundleListGitHubReleases           = bundle.ListGitHubReleases
 	bundlePromptIn           io.Reader = os.Stdin
@@ -166,6 +167,7 @@ func init() {
 	bundleInstallCmd.Flags().BoolVar(&bundleAuto, "auto", false, "Run in non-interactive mode (requires source-ref and --preset)")
 	bundleInstallCmd.Flags().BoolVar(&bundleForce, "force", false, "Overwrite existing files")
 	bundleInstallCmd.Flags().BoolVar(&bundleDryRun, "dry-run", false, "Show what would be done without doing it")
+	bundleInstallCmd.Flags().BoolVar(&bundleInstallAssets, "assets", true, "Install prompt files to .opencode/ directory")
 	bundleInstallCmd.ValidArgsFunction = completeSourceRefs
 	_ = bundleInstallCmd.RegisterFlagCompletionFunc("preset", completeBundlePresetNames)
 	bundleUpdateCmd.ValidArgsFunction = completeSourceRefs
@@ -270,15 +272,30 @@ func runBundleInstall(sourceRef string, interactivePreset bool) error {
 	}
 	fmt.Printf("written: %s\n", outputPath)
 
+	// Install prompt files if enabled and present
+	var installedAssets []bundle.InstalledAsset
+	if bundleInstallAssets && len(bundlePresetEntry.PromptFiles) > 0 {
+		installed, err := installPromptFiles(bundleRoot, projectRoot, bundlePresetEntry.PromptFiles, bundleForce)
+		if err != nil {
+			return fmt.Errorf("failed to install prompt files: %w", err)
+		}
+		installedAssets = installed
+
+		for _, a := range installed {
+			fmt.Printf("written: %s\n", a.Destination)
+		}
+	}
+
 	// Write provenance
 	prov := &bundle.Provenance{
-		SourceID:      src.ID,
-		SourceName:    src.Name,
-		SourceType:    string(src.Type),
-		BundleVersion: manifest.BundleVersion,
-		PresetName:    selectedPreset,
-		Entrypoint:    bundlePresetEntry.Entrypoint,
-		AppliedAt:     "2026-03-31T00:00:00Z", // Would use time.Now().Format(time.RFC3339)
+		SourceID:        src.ID,
+		SourceName:      src.Name,
+		SourceType:      string(src.Type),
+		BundleVersion:   manifest.BundleVersion,
+		PresetName:      selectedPreset,
+		Entrypoint:      bundlePresetEntry.Entrypoint,
+		AppliedAt:       "2026-03-31T00:00:00Z", // Would use time.Now().Format(time.RFC3339)
+		InstalledAssets: installedAssets,
 	}
 
 	if err := bundle.SaveProvenance(projectRoot, prov, bundleForce); err != nil {
@@ -288,6 +305,67 @@ func runBundleInstall(sourceRef string, interactivePreset bool) error {
 	fmt.Println("done: bundle applied")
 
 	return nil
+}
+
+// installPromptFiles copies prompt files from the bundle to the project's .opencode/prompts/ directory.
+func installPromptFiles(bundleRoot, projectRoot string, promptFiles []string, force bool) ([]bundle.InstalledAsset, error) {
+	if len(promptFiles) == 0 {
+		return nil, nil
+	}
+
+	var installed []bundle.InstalledAsset
+	promptsDir := filepath.Join(projectRoot, ".opencode", "prompts")
+
+	// Create prompts directory if it doesn't exist
+	if err := os.MkdirAll(promptsDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create prompts directory: %w", err)
+	}
+
+	for _, pf := range promptFiles {
+		sourcePath := filepath.Join(bundleRoot, pf)
+
+		// Verify source file exists
+		if _, err := os.Stat(sourcePath); err != nil {
+			return nil, fmt.Errorf("prompt file not found in bundle: %s", pf)
+		}
+
+		// Determine destination (preserve relative structure)
+		destPath := filepath.Join(promptsDir, filepath.Base(pf))
+
+		// Create subdirectory if needed (for paths like prompts/subdir/file.md)
+		if strings.Contains(pf, string(filepath.Separator)) {
+			subdir := filepath.Dir(pf)
+			subdirPath := filepath.Join(promptsDir, subdir)
+			if err := os.MkdirAll(subdirPath, 0755); err != nil {
+				return nil, fmt.Errorf("failed to create subdirectory: %w", err)
+			}
+			destPath = filepath.Join(promptsDir, pf)
+		}
+
+		// Check if destination exists (unless force)
+		if !force {
+			if _, err := os.Stat(destPath); err == nil {
+				return nil, fmt.Errorf("prompt file already exists: %s (use --force to overwrite)", destPath)
+			}
+		}
+
+		// Copy the file
+		sourceData, err := os.ReadFile(sourcePath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read prompt file: %w", err)
+		}
+
+		if err := os.WriteFile(destPath, sourceData, 0644); err != nil {
+			return nil, fmt.Errorf("failed to write prompt file: %w", err)
+		}
+
+		installed = append(installed, bundle.InstalledAsset{
+			Source:      pf,
+			Destination: destPath,
+		})
+	}
+
+	return installed, nil
 }
 
 func resolveGitHubBundleVersion(sourceLocation, requestedVersion string, allowPrompt bool) (string, error) {

--- a/docs/config-bundles.md
+++ b/docs/config-bundles.md
@@ -41,6 +41,13 @@ oc bundle apply qbic --version v1.0.0 --preset mixed --project-root .
 oc bundle apply qbic --preset mixed --project-root .
 ```
 
+**Prompt files:** If the preset declares `prompt_files` in the manifest, those files are automatically installed to `.opencode/prompts/` in your project. This allows agent configs to reference them using `{file:.opencode/prompts/filename.md}`.
+
+**Controlling asset installation:**
+- `--assets=true` (default): Install prompt files automatically
+- `--assets=false`: Skip prompt file installation
+- `--force`: Overwrite existing files
+
 If a source publishes multiple versions, the CLI should support:
 
 - explicit version selection with `--version <tag>`
@@ -87,19 +94,45 @@ Create `opencode-bundle.manifest.json` at your bundle root:
 | `entrypoint` | Path to preset JSON file |
 | `prompt_files` | Array of prompt file paths (can be empty) |
 
-### 4. Publish as GitHub Release
+### 4. Add Prompt Files (Optional)
+
+If your preset includes agent configurations that reference custom prompts, include those in your bundle:
+
+```
+my-bundle/
+├── opencode-bundle.manifest.json
+├── opencode.default.json
+└── prompts/
+    ├── coder.md
+    └── reviewer.md
+```
+
+Reference them in your preset config:
+
+```json
+{
+  "agent": {
+    "coder": {
+      "prompt": "{file:.opencode/prompts/coder.md}"
+    }
+  }
+}
+```
+
+### 5. Publish as GitHub Release
 
 1. Create a GitHub release. Stable releases and prereleases are both valid bundle sources.
 2. Attach a `.tar.gz` bundle archive containing:
    - `opencode-bundle.manifest.json` at root, or under a single top-level directory
    - All preset files referenced by the manifest
+   - All prompt files referenced in `prompt_files` arrays
    - `.opencode/schemas/` when your bundle ships the canonical session schemas
 3. Attach a matching `-checksums.txt` file using SHA-256.
 4. Do not rely on GitHub's auto-generated source tarballs as the primary consumable bundle artifact.
 
 See `docs/specs/bundle-contract.md` for the full GitHub-release distribution contract and a copy-pasteable GitHub Actions example workflow.
 
-### 5. Register Your Bundle
+### 6. Register Your Bundle
 
 ```sh
 oc source add your-username/your-bundle --name mybundle

--- a/docs/specs/bundle-contract.md
+++ b/docs/specs/bundle-contract.md
@@ -109,6 +109,84 @@ This file is embedded into the `oc` CLI binary at build time.
 | `entrypoint` | string | Yes | Path to preset JSON file relative to bundle root |
 | `prompt_files` | array | Yes | Array of prompt file paths (can be empty) |
 
+---
+
+## Asset Installation
+
+This section describes how bundle assets (prompts, and in future releases agents, commands, tools) are installed to the local project.
+
+### Prompt File Installation
+
+When applying a preset that declares `prompt_files`, the CLI copies those files to the project's `.opencode/prompts/` directory.
+
+**Installation behavior:**
+- **Target directory**: `.opencode/prompts/` (project-local)
+- **Path preservation**: Relative structure is preserved (e.g., `prompts/subdir/file.md` → `.opencode/prompts/subdir/file.md`)
+- **Default behavior**: Prompt files are installed automatically when declared in the preset
+- **Skip installation**: Use `--assets=false` to skip prompt file installation
+
+**Example:**
+
+Given a bundle with this manifest:
+```json
+{
+  "presets": [{
+    "name": "default",
+    "entrypoint": "configs/default.json",
+    "prompt_files": ["prompts/coder.md", "prompts/reviewer.md"]
+  }]
+}
+```
+
+After running `oc bundle apply <source> --preset default`:
+```
+<project-root>/
+├── .opencode/
+│   ├── prompts/
+│   │   ├── coder.md
+│   │   └── reviewer.md
+│   ├── bundle-provenance.json
+│   └── opencode.json  (or project root, based on --output flag)
+```
+
+**Agent config reference:**
+
+The preset's `opencode.json` can reference installed prompts using the `{file:...}` syntax:
+
+```json
+{
+  "agent": {
+    "coder": {
+      "prompt": "{file:.opencode/prompts/coder.md}"
+    }
+  }
+}
+```
+
+Path resolution: The `{file:...}` path is relative to where `opencode.json` is located. If `opencode.json` is at project root, use `.opencode/prompts/`. If it's in `.opencode/`, use `prompts/`.
+
+**CLI flags:**
+- `--assets=true` (default): Install prompt files when declared
+- `--assets=false`: Skip prompt file installation
+- `--force`: Overwrite existing prompt files
+
+**Provenance tracking:**
+
+Installed assets are tracked in `.opencode/bundle-provenance.json`:
+
+```json
+{
+  "source_id": "...",
+  "source_name": "...",
+  "installed_assets": [
+    {
+      "source": "prompts/coder.md",
+      "destination": "/path/to/project/.opencode/prompts/coder.md"
+    }
+  ]
+}
+```
+
 ### Optional Fields
 
 | Field | Type | Description |

--- a/e2e/testdata/bundle-with-prompts/configs/default.json
+++ b/e2e/testdata/bundle-with-prompts/configs/default.json
@@ -1,0 +1,8 @@
+{
+  "default_agent": "build",
+  "agent": {
+    "coder": {
+      "prompt": "{file:.opencode/prompts/coder.md}"
+    }
+  }
+}

--- a/e2e/testdata/bundle-with-prompts/opencode-bundle.manifest.json
+++ b/e2e/testdata/bundle-with-prompts/opencode-bundle.manifest.json
@@ -1,0 +1,13 @@
+{
+  "manifest_version": "1.0.0",
+  "bundle_name": "bundle-with-prompts",
+  "bundle_version": "v1.0.0",
+  "presets": [
+    {
+      "name": "default",
+      "entrypoint": "configs/default.json",
+      "description": "Preset with prompts",
+      "prompt_files": ["prompts/coder.md"]
+    }
+  ]
+}

--- a/e2e/testdata/bundle-with-prompts/prompts/coder.md
+++ b/e2e/testdata/bundle-with-prompts/prompts/coder.md
@@ -1,0 +1,1 @@
+You are a coder agent specialized in implementation.

--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -66,15 +66,22 @@ type Preset struct {
 	Description string   `json:"description,omitempty"`
 }
 
+// InstalledAsset represents a file installed from a bundle to the project.
+type InstalledAsset struct {
+	Source      string `json:"source"`      // Path in bundle (relative to bundle root)
+	Destination string `json:"destination"` // Relative path in project .opencode/
+}
+
 // Provenance represents the bundle provenance file stored in the project.
 type Provenance struct {
-	SourceID      string `json:"source_id"`
-	SourceName    string `json:"source_name"`
-	SourceType    string `json:"source_type"`
-	BundleVersion string `json:"bundle_version"`
-	PresetName    string `json:"preset_name"`
-	Entrypoint    string `json:"entrypoint"`
-	AppliedAt     string `json:"applied_at"`
+	SourceID        string           `json:"source_id"`
+	SourceName      string           `json:"source_name"`
+	SourceType      string           `json:"source_type"`
+	BundleVersion   string           `json:"bundle_version"`
+	PresetName      string           `json:"preset_name"`
+	Entrypoint      string           `json:"entrypoint"`
+	AppliedAt       string           `json:"applied_at"`
+	InstalledAssets []InstalledAsset `json:"installed_assets,omitempty"`
 }
 
 // LoadManifest loads a bundle manifest from the given path.


### PR DESCRIPTION
## Summary

- Adds support for installing prompt files referenced in bundle presets to the local `.opencode/prompts/` directory
- New `--assets` flag (default: true) to control prompt file installation
- Provenance now tracks installed assets for traceability
- Includes test fixture `bundle-with-prompts` for e2e testing

## Changes

### Code
- `internal/bundle/bundle.go`: Added `InstalledAsset` struct and `InstalledAssets` field to `Provenance`
- `cmd/bundle.go`: Added `bundleInstallAssets` flag, `--assets` flag registration, `installPromptFiles()` function

### Documentation  
- `docs/specs/bundle-contract.md`: Added "Asset Installation" section with detailed behavior
- `docs/config-bundles.md`: Added user-facing documentation for prompt file installation

## Usage

```bash
# Apply preset with prompt files (default)
oc bundle apply qbic --preset default

# Skip prompt files
oc bundle apply qbic --preset default --assets=false

# Overwrite existing files
oc bundle apply qbic --preset default --force
```

When a preset declares `prompt_files`, they are installed to `.opencode/prompts/` and can be referenced in agent configs via `{file:.opencode/prompts/filename.md}`.