### PR TITLE
fix: restore bundle install command (reverts accidental apply)

### DIFF
--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -52,35 +52,35 @@ var bundleCmd = &cobra.Command{
 	Short: "Manage OpenCode configuration bundles",
 	Long: `Manage OpenCode configuration bundles.
 
-Apply, track, and update configuration bundles from registered sources.
+Install, track, and update configuration bundles from registered sources.
 
 Examples:
-	  oc bundle apply qbic --preset default
-	  oc bundle apply qbic
+	  oc bundle install qbic --preset default
+	  oc bundle install qbic
 	  oc bundle status
 	  oc bundle update abc12345`,
 }
 
-// bundleApplyCmd applies a preset from a registered config bundle
-var bundleApplyCmd = &cobra.Command{
-	Use:   "apply [source-ref]",
-	Short: "Apply a preset from a config bundle",
-	Long: `Apply a preset from a registered config bundle to a project.
+// bundleInstallCmd installs a preset from a registered config bundle
+var bundleInstallCmd = &cobra.Command{
+	Use:   "install [source-ref]",
+	Short: "Install a preset from a config bundle",
+	Long: `Install a preset from a registered config bundle to a project.
 
 The source-ref may be either a registered source ID or a unique source name.
 When omitted in interactive mode, the command prompts for source and preset selection.
 
 Examples:
-	  oc bundle apply qbic --preset default
-	  oc bundle apply qbic
-	  oc bundle apply abc12345 --version v1.2.3 --preset default
-	  oc bundle apply qbic --preset minimal --project-root ./myproject
-	  oc bundle apply qbic --auto --preset default --force
-	  oc bundle apply (interactive mode)`,
+	  oc bundle install qbic --preset default
+	  oc bundle install qbic
+	  oc bundle install abc12345 --version v1.2.3 --preset default
+	  oc bundle install qbic --preset minimal --project-root ./myproject
+	  oc bundle install qbic --auto --preset default --force
+	  oc bundle install (interactive mode)`,
 	Args: cobra.RangeArgs(0, 1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) > 0 {
-			return runBundleApply(args[0], false)
+			return runBundleInstall(args[0], false)
 		}
 		// No arguments provided - enter interactive mode
 		if !bundleInputIsTTY() || bundleAuto {
@@ -91,7 +91,7 @@ Examples:
 		if err != nil {
 			return err
 		}
-		return runBundleApply(sourceRef, true)
+		return runBundleInstall(sourceRef, true)
 	},
 }
 
@@ -153,21 +153,21 @@ func init() {
 	rootCmd.AddCommand(bundleCmd)
 
 	// Add subcommands
-	bundleCmd.AddCommand(bundleApplyCmd)
+	bundleCmd.AddCommand(bundleInstallCmd)
 	bundleCmd.AddCommand(bundleStatusCmd)
 	bundleCmd.AddCommand(bundleUpdateCmd)
 	bundleCmd.AddCommand(bundleInitCmd)
 
 	// Flags for bundle apply
-	bundleApplyCmd.Flags().StringVar(&bundlePreset, "preset", "", "Preset name to apply")
-	bundleApplyCmd.Flags().StringVar(&bundleVersion, "version", "", "Bundle version/tag to apply for github-release sources")
-	bundleApplyCmd.Flags().StringVar(&bundleProjectRoot, "project-root", ".", "Project root directory")
-	bundleApplyCmd.Flags().StringVar(&bundleOutput, "output", "opencode.json", "Output file path")
-	bundleApplyCmd.Flags().BoolVar(&bundleAuto, "auto", false, "Run in non-interactive mode (requires source-ref and --preset)")
-	bundleApplyCmd.Flags().BoolVar(&bundleForce, "force", false, "Overwrite existing files")
-	bundleApplyCmd.Flags().BoolVar(&bundleDryRun, "dry-run", false, "Show what would be done without doing it")
-	bundleApplyCmd.ValidArgsFunction = completeSourceRefs
-	_ = bundleApplyCmd.RegisterFlagCompletionFunc("preset", completeBundlePresetNames)
+	bundleInstallCmd.Flags().StringVar(&bundlePreset, "preset", "", "Preset name to apply")
+	bundleInstallCmd.Flags().StringVar(&bundleVersion, "version", "", "Bundle version/tag to apply for github-release sources")
+	bundleInstallCmd.Flags().StringVar(&bundleProjectRoot, "project-root", ".", "Project root directory")
+	bundleInstallCmd.Flags().StringVar(&bundleOutput, "output", "opencode.json", "Output file path")
+	bundleInstallCmd.Flags().BoolVar(&bundleAuto, "auto", false, "Run in non-interactive mode (requires source-ref and --preset)")
+	bundleInstallCmd.Flags().BoolVar(&bundleForce, "force", false, "Overwrite existing files")
+	bundleInstallCmd.Flags().BoolVar(&bundleDryRun, "dry-run", false, "Show what would be done without doing it")
+	bundleInstallCmd.ValidArgsFunction = completeSourceRefs
+	_ = bundleInstallCmd.RegisterFlagCompletionFunc("preset", completeBundlePresetNames)
 	bundleUpdateCmd.ValidArgsFunction = completeSourceRefs
 
 	// Flags for bundle status
@@ -183,7 +183,7 @@ func init() {
 	bundleInitCmd.Flags().BoolVar(&bundleInitForce, "force", false, "Overwrite existing directory contents")
 }
 
-func runBundleApply(sourceRef string, interactivePreset bool) error {
+func runBundleInstall(sourceRef string, interactivePreset bool) error {
 	// Resolve project root
 	projectRoot, err := filepath.Abs(bundleProjectRoot)
 	if err != nil {

--- a/cmd/bundle_test.go
+++ b/cmd/bundle_test.go
@@ -53,9 +53,9 @@ func TestBundleApplyNoSource(t *testing.T) {
 	bundleProjectRoot = "."
 	bundleDryRun = false
 
-	err := runBundleApply("nonexistent-id", false)
+	err := runBundleInstall("nonexistent-id", false)
 	if err == nil {
-		t.Error("runBundleApply() expected error for nonexistent source")
+		t.Error("runBundleInstall() expected error for nonexistent source")
 	}
 }
 
@@ -95,12 +95,12 @@ func TestBundleApplyMissingPreset(t *testing.T) {
 	bundleInputIsTTY = func() bool { return false }
 	bundleProjectRoot = t.TempDir()
 
-	err := runBundleApply("abc12345", false)
+	err := runBundleInstall("abc12345", false)
 	if err == nil {
-		t.Error("runBundleApply() expected error when preset is missing")
+		t.Error("runBundleInstall() expected error when preset is missing")
 	}
 	if !strings.Contains(err.Error(), "--preset is required outside interactive mode") {
-		t.Fatalf("runBundleApply() error = %v", err)
+		t.Fatalf("runBundleInstall() error = %v", err)
 	}
 }
 
@@ -219,8 +219,8 @@ func TestBundleApplyPassesVersionForGitHubSources(t *testing.T) {
 		return bundleRoot, func() {}, nil
 	}
 
-	if err := runBundleApply("github1", false); err != nil {
-		t.Fatalf("runBundleApply() error = %v", err)
+	if err := runBundleInstall("github1", false); err != nil {
+		t.Fatalf("runBundleInstall() error = %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(projectRoot, "opencode.json")); err != nil {
 		t.Fatalf("expected opencode.json to be written: %v", err)
@@ -291,8 +291,8 @@ func TestBundleApplyInteractiveSelectsGitHubReleaseVersion(t *testing.T) {
 		return bundleRoot, func() {}, nil
 	}
 
-	if err := runBundleApply("github1", false); err != nil {
-		t.Fatalf("runBundleApply() error = %v", err)
+	if err := runBundleInstall("github1", false); err != nil {
+		t.Fatalf("runBundleInstall() error = %v", err)
 	}
 }
 
@@ -329,12 +329,12 @@ func TestBundleApplyGitHubSourceRequiresVersionOutsideInteractiveMode(t *testing
 		return []bundle.GitHubReleaseVersion{{TagName: "v1.3.0", Prerelease: false}, {TagName: "v1.4.0-alpha.1", Prerelease: true}}, nil
 	}
 
-	err := runBundleApply("github1", false)
+	err := runBundleInstall("github1", false)
 	if err == nil {
-		t.Fatal("runBundleApply() error = nil, want version-selection error")
+		t.Fatal("runBundleInstall() error = nil, want version-selection error")
 	}
 	if !strings.Contains(err.Error(), "--version is required for github-release sources outside interactive mode") {
-		t.Fatalf("runBundleApply() error = %v", err)
+		t.Fatalf("runBundleInstall() error = %v", err)
 	}
 }
 
@@ -371,12 +371,12 @@ func TestBundleApplyGitHubSourceReportsPrereleaseOnlyOutsideInteractiveMode(t *t
 		return []bundle.GitHubReleaseVersion{{TagName: "v1.4.0-alpha.1", Prerelease: true}, {TagName: "v1.3.0-alpha.2", Prerelease: true}}, nil
 	}
 
-	err := runBundleApply("github1", false)
+	err := runBundleInstall("github1", false)
 	if err == nil {
-		t.Fatal("runBundleApply() error = nil, want prerelease-only version-selection error")
+		t.Fatal("runBundleInstall() error = nil, want prerelease-only version-selection error")
 	}
 	if !strings.Contains(err.Error(), "only prereleases are available") {
-		t.Fatalf("runBundleApply() error = %v", err)
+		t.Fatalf("runBundleInstall() error = %v", err)
 	}
 }
 
@@ -413,12 +413,12 @@ func TestBundleApplyGitHubSourceSinglePrereleaseStillRequiresVersionOutsideInter
 		return []bundle.GitHubReleaseVersion{{TagName: "v1.4.0-alpha.1", Prerelease: true}}, nil
 	}
 
-	err := runBundleApply("github1", false)
+	err := runBundleInstall("github1", false)
 	if err == nil {
-		t.Fatal("runBundleApply() error = nil, want prerelease-only version-selection error")
+		t.Fatal("runBundleInstall() error = nil, want prerelease-only version-selection error")
 	}
 	if !strings.Contains(err.Error(), "only prereleases are available") {
-		t.Fatalf("runBundleApply() error = %v", err)
+		t.Fatalf("runBundleInstall() error = %v", err)
 	}
 }
 
@@ -478,21 +478,21 @@ func TestCompleteBundlePresetNamesGitHubSourceUsesNonInteractiveInspection(t *te
 	}
 }
 
-// TestBundleApplyFlags tests that bundle apply flags are properly configured
-func TestBundleApplyFlags(t *testing.T) {
-	if bundleApplyCmd.Flags().Lookup("preset") == nil {
+// TestBundleInstallFlags tests that bundle install flags are properly configured
+func TestBundleInstallFlags(t *testing.T) {
+	if bundleInstallCmd.Flags().Lookup("preset") == nil {
 		t.Error("preset flag should exist on bundle apply command")
 	}
-	if bundleApplyCmd.Flags().Lookup("auto") == nil {
+	if bundleInstallCmd.Flags().Lookup("auto") == nil {
 		t.Error("auto flag should exist on bundle apply command")
 	}
-	if bundleApplyCmd.Flags().Lookup("project-root") == nil {
+	if bundleInstallCmd.Flags().Lookup("project-root") == nil {
 		t.Error("project-root flag should exist on bundle apply command")
 	}
-	if bundleApplyCmd.Flags().Lookup("force") == nil {
+	if bundleInstallCmd.Flags().Lookup("force") == nil {
 		t.Error("force flag should exist on bundle apply command")
 	}
-	if bundleApplyCmd.Flags().Lookup("dry-run") == nil {
+	if bundleInstallCmd.Flags().Lookup("dry-run") == nil {
 		t.Error("dry-run flag should exist on bundle apply command")
 	}
 }
@@ -512,7 +512,7 @@ func TestBundleUpdateFlags(t *testing.T) {
 }
 
 func TestBundleApplyVersionFlagExists(t *testing.T) {
-	if bundleApplyCmd.Flags().Lookup("version") == nil {
+	if bundleInstallCmd.Flags().Lookup("version") == nil {
 		t.Fatal("version flag should exist on bundle apply command")
 	}
 }
@@ -557,12 +557,12 @@ func TestBundleApplyRejectsVersionForLocalSources(t *testing.T) {
 	bundleProjectRoot = projectRoot
 	bundleVersion = "v1.2.3"
 
-	err := runBundleApply("local1", false)
+	err := runBundleInstall("local1", false)
 	if err == nil {
-		t.Fatal("runBundleApply() error = nil, want error")
+		t.Fatal("runBundleInstall() error = nil, want error")
 	}
 	if !strings.Contains(err.Error(), "--version is only supported for github-release sources") {
-		t.Fatalf("runBundleApply() error = %v", err)
+		t.Fatalf("runBundleInstall() error = %v", err)
 	}
 }
 
@@ -603,8 +603,8 @@ func TestBundleApplyResolvesSourceByName(t *testing.T) {
 	bundlePreset = "test"
 	bundleProjectRoot = projectRoot
 
-	if err := runBundleApply("qbic", false); err != nil {
-		t.Fatalf("runBundleApply() error = %v", err)
+	if err := runBundleInstall("qbic", false); err != nil {
+		t.Fatalf("runBundleInstall() error = %v", err)
 	}
 
 	prov, err := bundle.LoadProvenance(projectRoot)
@@ -630,12 +630,12 @@ func TestBundleApplyRejectsAmbiguousSourceName(t *testing.T) {
 	bundlePreset = "test"
 	defer func() { bundlePreset = origPreset }()
 
-	err := runBundleApply("qbic", false)
+	err := runBundleInstall("qbic", false)
 	if err == nil {
-		t.Fatal("runBundleApply() error = nil, want ambiguous source error")
+		t.Fatal("runBundleInstall() error = nil, want ambiguous source error")
 	}
 	if !strings.Contains(err.Error(), "ambiguous") || !strings.Contains(err.Error(), "id-1") || !strings.Contains(err.Error(), "id-2") {
-		t.Fatalf("runBundleApply() error = %v", err)
+		t.Fatalf("runBundleInstall() error = %v", err)
 	}
 }
 
@@ -684,8 +684,8 @@ func TestBundleApplyInteractiveSelectsPreset(t *testing.T) {
 	bundlePromptIn = strings.NewReader("2\n")
 	bundlePromptOut = io.Discard
 
-	if err := runBundleApply("qbic", false); err != nil {
-		t.Fatalf("runBundleApply() error = %v", err)
+	if err := runBundleInstall("qbic", false); err != nil {
+		t.Fatalf("runBundleInstall() error = %v", err)
 	}
 
 	content, err := os.ReadFile(filepath.Join(projectRoot, "opencode.json"))

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -62,7 +62,7 @@ func TestLocalDirectoryFlow(t *testing.T) {
 	requireContains(t, listResult.stdout, "fixture-dir")
 	requireContains(t, listResult.stdout, "local-directory")
 
-	applyResult := runOC(t, env, "bundle", "apply", sourceID, "--preset", "fixture", "--project-root", projectRoot)
+	applyResult := runOC(t, env, "bundle", "install", sourceID, "--preset", "fixture", "--project-root", projectRoot)
 	requireSuccess(t, applyResult)
 
 	configPath := filepath.Join(projectRoot, "opencode.json")
@@ -91,11 +91,11 @@ func TestLocalDirectoryFlow(t *testing.T) {
 	requireContains(t, statusResult.stdout, "fixture-dir")
 	requireContains(t, statusResult.stdout, "fixture")
 
-	overwriteResult := runOC(t, env, "bundle", "apply", sourceID, "--preset", "fixture", "--project-root", projectRoot)
+	overwriteResult := runOC(t, env, "bundle", "install", sourceID, "--preset", "fixture", "--project-root", projectRoot)
 	requireFailure(t, overwriteResult)
 	requireContains(t, overwriteResult.stderr, "output file exists")
 
-	forceResult := runOC(t, env, "bundle", "apply", sourceID, "--preset", "fixture", "--project-root", projectRoot, "--force")
+	forceResult := runOC(t, env, "bundle", "install", sourceID, "--preset", "fixture", "--project-root", projectRoot, "--force")
 	requireSuccess(t, forceResult)
 	updatedProv := readProvenance(t, provenancePath)
 	if updatedProv.SourceID != sourceID {
@@ -114,7 +114,7 @@ func TestLocalDirectoryApplyBySourceName(t *testing.T) {
 	addResult := runOC(t, env, "source", "add", bundleDir, "--name", "fixture-dir")
 	requireSuccess(t, addResult)
 
-	applyResult := runOC(t, env, "bundle", "apply", "fixture-dir", "--preset", "fixture", "--project-root", projectRoot)
+	applyResult := runOC(t, env, "bundle", "install", "fixture-dir", "--preset", "fixture", "--project-root", projectRoot)
 	requireSuccess(t, applyResult)
 
 	prov := readProvenance(t, filepath.Join(projectRoot, ".opencode", "bundle-provenance.json"))
@@ -137,7 +137,7 @@ func TestLocalArchiveFlow(t *testing.T) {
 	requireSuccess(t, addResult)
 	sourceID := extractSourceID(t, addResult.stdout)
 
-	applyResult := runOC(t, env, "bundle", "apply", sourceID, "--preset", "fixture", "--project-root", projectRoot)
+	applyResult := runOC(t, env, "bundle", "install", sourceID, "--preset", "fixture", "--project-root", projectRoot)
 	requireSuccess(t, applyResult)
 
 	provenancePath := filepath.Join(projectRoot, ".opencode", "bundle-provenance.json")
@@ -168,7 +168,7 @@ func TestGitHubReleaseFlow(t *testing.T) {
 	requireSuccess(t, addResult)
 	sourceID := extractSourceID(t, addResult.stdout)
 
-	applyResult := runOC(t, env, "bundle", "apply", sourceID, "--version", "v1.2.3", "--preset", "fixture", "--project-root", projectRoot)
+	applyResult := runOC(t, env, "bundle", "install", sourceID, "--version", "v1.2.3", "--preset", "fixture", "--project-root", projectRoot)
 	requireSuccess(t, applyResult)
 
 	configPath := filepath.Join(projectRoot, "opencode.json")
@@ -208,7 +208,7 @@ func TestGitHubReleaseInteractiveVersionSelectionFlow(t *testing.T) {
 	requireSuccess(t, addResult)
 	sourceID := extractSourceID(t, addResult.stdout)
 
-	applyResult := runOCInPTY(t, env, "1\n", "bundle", "apply", sourceID, "--preset", "fixture", "--project-root", projectRoot)
+	applyResult := runOCInPTY(t, env, "1\n", "bundle", "install", sourceID, "--preset", "fixture", "--project-root", projectRoot)
 	requireSuccess(t, applyResult)
 	requireContains(t, applyResult.stdout, "Available versions for owner/repo:")
 	requireContains(t, applyResult.stdout, "v1.3.0-alpha.1 (prerelease)")
@@ -246,7 +246,7 @@ func TestGitHubReleaseApplyWithoutVersionNonInteractiveFails(t *testing.T) {
 	requireSuccess(t, addResult)
 	sourceID := extractSourceID(t, addResult.stdout)
 
-	applyResult := runOCWithStdin(t, env, strings.NewReader(""), "bundle", "apply", sourceID, "--preset", "fixture", "--project-root", projectRoot)
+	applyResult := runOCWithStdin(t, env, strings.NewReader(""), "bundle", "install", sourceID, "--preset", "fixture", "--project-root", projectRoot)
 	requireFailure(t, applyResult)
 	requireContains(t, applyResult.stderr, "--version is required for github-release sources outside interactive mode")
 	if strings.Contains(applyResult.stderr, "Select a version") || strings.Contains(applyResult.stdout, "Select a version") {
@@ -254,14 +254,14 @@ func TestGitHubReleaseApplyWithoutVersionNonInteractiveFails(t *testing.T) {
 	}
 }
 
-func TestBundleApplyFailsForUnknownSource(t *testing.T) {
+func TestBundleInstallFailsForUnknownSource(t *testing.T) {
 	projectRoot := t.TempDir()
-	result := runOC(t, testEnv(t), "bundle", "apply", "missing-id", "--preset", "fixture", "--project-root", projectRoot)
+	result := runOC(t, testEnv(t), "bundle", "install", "missing-id", "--preset", "fixture", "--project-root", projectRoot)
 	requireFailure(t, result)
 	requireContains(t, result.stderr, "source not found")
 }
 
-func TestBundleApplyRequiresPresetOutsideTTY(t *testing.T) {
+func TestBundleInstallRequiresPresetOutsideTTY(t *testing.T) {
 	env := testEnv(t)
 	bundleDir := copyFixtureBundle(t)
 	projectRoot := t.TempDir()
@@ -269,16 +269,16 @@ func TestBundleApplyRequiresPresetOutsideTTY(t *testing.T) {
 	addResult := runOC(t, env, "source", "add", bundleDir, "--name", "fixture-dir")
 	requireSuccess(t, addResult)
 
-	applyResult := runOCWithStdin(t, env, strings.NewReader(""), "bundle", "apply", "fixture-dir", "--project-root", projectRoot)
+	applyResult := runOCWithStdin(t, env, strings.NewReader(""), "bundle", "install", "fixture-dir", "--project-root", projectRoot)
 	requireFailure(t, applyResult)
 	requireContains(t, applyResult.stderr, "--preset is required outside interactive mode")
 }
 
-func TestBundleApplyNoArgsFailsInNonTTY(t *testing.T) {
+func TestBundleInstallNoArgsFailsInNonTTY(t *testing.T) {
 	// When run without arguments in non-TTY (e2e tests), should fail with helpful message
 	// Use empty stdin to ensure no TTY is detected
 	projectRoot := t.TempDir()
-	result := runOCWithStdin(t, testEnv(t), strings.NewReader(""), "bundle", "apply", "--project-root", projectRoot)
+	result := runOCWithStdin(t, testEnv(t), strings.NewReader(""), "bundle", "install", "--project-root", projectRoot)
 	requireFailure(t, result)
 	// When there are no sources, it should fail with "no sources registered"
 	// OR when there are sources but no TTY, fail with "source-ref is required"
@@ -286,7 +286,7 @@ func TestBundleApplyNoArgsFailsInNonTTY(t *testing.T) {
 	requireContains(t, result.stderr, "non-interactive mode")
 }
 
-func TestBundleApplyAutoFlagRequiresSourceRef(t *testing.T) {
+func TestBundleInstallAutoFlagRequiresSourceRef(t *testing.T) {
 	// --auto flag should require source-ref argument regardless of TTY
 	env := testEnv(t)
 	bundleDir := copyFixtureBundle(t)
@@ -296,13 +296,13 @@ func TestBundleApplyAutoFlagRequiresSourceRef(t *testing.T) {
 
 	projectRoot := t.TempDir()
 	// Using --auto without source-ref should fail
-	result := runOCWithStdin(t, env, strings.NewReader(""), "bundle", "apply", "--auto", "--project-root", projectRoot)
+	result := runOCWithStdin(t, env, strings.NewReader(""), "bundle", "install", "--auto", "--project-root", projectRoot)
 	requireFailure(t, result)
 	requireContains(t, result.stderr, "source-ref is required")
 	requireContains(t, result.stderr, "--auto")
 }
 
-func TestBundleApplyAutoFlagWithPresetRequiresSource(t *testing.T) {
+func TestBundleInstallAutoFlagWithPresetRequiresSource(t *testing.T) {
 	// --auto with --preset but no source-ref should fail
 	env := testEnv(t)
 	bundleDir := copyFixtureBundle(t)
@@ -311,7 +311,7 @@ func TestBundleApplyAutoFlagWithPresetRequiresSource(t *testing.T) {
 	requireSuccess(t, addResult)
 
 	projectRoot := t.TempDir()
-	result := runOCWithStdin(t, env, strings.NewReader(""), "bundle", "apply", "--auto", "--preset", "fixture", "--project-root", projectRoot)
+	result := runOCWithStdin(t, env, strings.NewReader(""), "bundle", "install", "--auto", "--preset", "fixture", "--project-root", projectRoot)
 	requireFailure(t, result)
 	requireContains(t, result.stderr, "source-ref is required")
 }
@@ -321,6 +321,18 @@ func TestSourceAddFailsWithoutManifest(t *testing.T) {
 	result := runOC(t, testEnv(t), "source", "add", bundleDir)
 	requireFailure(t, result)
 	requireContains(t, result.stderr, "bundle manifest not found")
+}
+
+// TestBundleInstallCommandExists verifies the bundle install command exists (not apply)
+// This test ensures we don't accidentally revert to the old "apply" command name
+func TestBundleInstallCommandExists(t *testing.T) {
+	env := testEnv(t)
+	result := runOC(t, env, "bundle", "install", "--help")
+	requireSuccess(t, result)
+	// Verify the help output mentions "install" not "apply"
+	requireContains(t, result.stdout, "install [source-ref]")
+	// Ensure "apply" is not mentioned as the command name
+	requireNotContains(t, result.stdout, "apply [source-ref]")
 }
 
 func TestInvalidTarballFailsOnApply(t *testing.T) {
@@ -335,7 +347,7 @@ func TestInvalidTarballFailsOnApply(t *testing.T) {
 	sourceID := extractSourceID(t, addResult.stdout)
 
 	projectRoot := t.TempDir()
-	applyResult := runOC(t, env, "bundle", "apply", sourceID, "--preset", "fixture", "--project-root", projectRoot)
+	applyResult := runOC(t, env, "bundle", "install", sourceID, "--preset", "fixture", "--project-root", projectRoot)
 	requireFailure(t, applyResult)
 	requireContains(t, applyResult.stderr, "failed to resolve source")
 	if runtime.GOOS == "darwin" {
@@ -453,6 +465,13 @@ func requireContains(t *testing.T, haystack, needle string) {
 	t.Helper()
 	if !strings.Contains(haystack, needle) {
 		t.Fatalf("expected %q to contain %q", haystack, needle)
+	}
+}
+
+func requireNotContains(t *testing.T, haystack, needle string) {
+	t.Helper()
+	if strings.Contains(haystack, needle) {
+		t.Fatalf("expected %q to NOT contain %q", haystack, needle)
 	}
 }
 
@@ -882,7 +901,7 @@ func TestBundleInitGeneratedBundleIsValid(t *testing.T) {
 
 	// Try to apply the bundle
 	projectRoot := t.TempDir()
-	applyResult := runOCWithStdin(t, env, strings.NewReader(""), "bundle", "apply", "test-valid", "--preset", "default", "--project-root", projectRoot)
+	applyResult := runOCWithStdin(t, env, strings.NewReader(""), "bundle", "install", "test-valid", "--preset", "default", "--project-root", projectRoot)
 	requireSuccess(t, applyResult)
 
 	// Verify config was applied


### PR DESCRIPTION
## Summary

This fixes a regression where commit `2c97c2d` accidentally reverted the `bundle apply` → `bundle install` rename from commit `d842bf8`.

## Changes

- Rename `bundleApplyCmd` → `bundleInstallCmd`
- Rename `runBundleApply` → `runBundleInstall`
- Update help text and examples from "apply" to "install"
- Update unit tests to use the install command

## New E2E Test

Added `TestBundleInstallCommandExists` which specifically verifies:
- The `bundle install` command exists in help output
- The old `bundle apply` command does NOT exist

This test will fail if someone accidentally reverts to `apply` again.

## Verification

```bash
# Before fix - shows "apply [source-ref]"
occo bundle --help

# After fix - shows "install [source-ref]"
occo bundle --help
```