### PR TITLE
fix: add trailing newline to SectionHeader separator

### DIFF
--- a/internal/styles/styles.go
+++ b/internal/styles/styles.go
@@ -238,9 +238,9 @@ func SectionHeader(title string) string {
 		// Make header more prominent with accent color and bold
 		header := lipgloss.Style{}.Foreground(promptColor).Bold(true).Render(titleWithColon)
 		separator := MutedStyle.Render(strings.Repeat(sep, 36))
-		return header + "\n" + separator
+		return header + "\n" + separator + "\n"
 	}
-	return titleWithColon + "\n" + strings.Repeat(sep, 36)
+	return titleWithColon + "\n" + strings.Repeat(sep, 36) + "\n"
 }
 
 // Highlight outputs highlighted/important text


### PR DESCRIPTION
## Summary

- Fixes a bug where the first preset was displayed inline with the visual separator in preset selection prompts
- Added trailing newline after the separator in `SectionHeader` function in `internal/styles/styles.go`

## Before/After

**Before:**
```
Select Preset for <bundle>:
────────────────────────────────────  1) preset1
```

**After:**
```
Select Preset for <bundle>:
────────────────────────────────────
  1) preset1
```